### PR TITLE
Keyboard textedit changes

### DIFF
--- a/tt/classes/com/oddlabs/tt/gui/Box.java
+++ b/tt/classes/com/oddlabs/tt/gui/Box.java
@@ -1,5 +1,6 @@
-package com.oddlabs.tt.gui;
 
+package com.oddlabs.tt.gui;
+import org.lwjgl.opengl.GL11;
 import com.oddlabs.util.Quad;
 
 public final strictfp class Box {
@@ -83,5 +84,23 @@ public final strictfp class Box {
 
 	public final int getTopOffset() {
 		return top_offset;
+	}
+
+		/**
+	 * Renders a solid color rectangle for highlights (e.g., text selection).
+	 * @param x left position
+	 * @param y top position
+	 * @param width rectangle width
+	 * @param height rectangle height
+	 * @param r red (0-1)
+	 * @param g green (0-1)
+	 * @param b blue (0-1)
+	 * @param a alpha (0-1)
+	 */
+	public void renderHighlight(float x, float y, int width, int height) {
+		// Use the center quad for highlight rendering, set alpha if supported
+		if (center != null && center.length > 0 && center[Skin.NORMAL] != null) {
+			center[Skin.NORMAL].render(x, y, width, height);
+		}
 	}
 }

--- a/tt/classes/com/oddlabs/tt/gui/Box.java
+++ b/tt/classes/com/oddlabs/tt/gui/Box.java
@@ -1,106 +1,125 @@
-
 package com.oddlabs.tt.gui;
+
 import org.lwjgl.opengl.GL11;
 import com.oddlabs.util.Quad;
 
 public final strictfp class Box {
-	private final Quad[] left_bottom;
-	private final Quad[] bottom;
-	private final Quad[] right_bottom;
-	private final Quad[] right;
-	private final Quad[] right_top;
-	private final Quad[] top;
-	private final Quad[] left_top;
-	private final Quad[] left;
-	private final Quad[] center;
-	private final int left_offset;
-	private final int bottom_offset;
-	private final int right_offset;
-	private final int top_offset;
 
-	private final int left_width;
-	private final int right_width;
-	private final int bottom_height;
-	private final int top_height;
+    private final Quad[] left_bottom;
+    private final Quad[] bottom;
+    private final Quad[] right_bottom;
+    private final Quad[] right;
+    private final Quad[] right_top;
+    private final Quad[] top;
+    private final Quad[] left_top;
+    private final Quad[] left;
+    private final Quad[] center;
+    private final int left_offset;
+    private final int bottom_offset;
+    private final int right_offset;
+    private final int top_offset;
 
-	public Box(Quad[] left_bottom,
-			   Quad[] bottom,
-			   Quad[] right_bottom,
-			   Quad[] right,
-			   Quad[] right_top,
-			   Quad[] top,
-			   Quad[] left_top,
-			   Quad[] left,
-			   Quad[] center,
-			   int left_offset,
-			   int bottom_offset,
-			   int right_offset,
-			   int top_offset) {
-		this.left_bottom = left_bottom;
-		this.bottom = bottom;
-		this.right_bottom = right_bottom;
-		this.right = right;
-		this.right_top = right_top;
-		this.top = top;
-		this.left_top = left_top;
-		this.left = left;
-		this.center = center;
-		this.left_offset = left_offset;
-		this.bottom_offset = bottom_offset;
-		this.right_offset = right_offset;
-		this.top_offset = top_offset;
+    private final int left_width;
+    private final int right_width;
+    private final int bottom_height;
+    private final int top_height;
 
-		left_width = left[Skin.NORMAL].getWidth();
-		right_width = right[Skin.NORMAL].getWidth();
-		bottom_height = bottom[Skin.NORMAL].getHeight();
-		top_height = top[Skin.NORMAL].getHeight();
-	}
+    public Box(Quad[] left_bottom,
+            Quad[] bottom,
+            Quad[] right_bottom,
+            Quad[] right,
+            Quad[] right_top,
+            Quad[] top,
+            Quad[] left_top,
+            Quad[] left,
+            Quad[] center,
+            int left_offset,
+            int bottom_offset,
+            int right_offset,
+            int top_offset) {
+        this.left_bottom = left_bottom;
+        this.bottom = bottom;
+        this.right_bottom = right_bottom;
+        this.right = right;
+        this.right_top = right_top;
+        this.top = top;
+        this.left_top = left_top;
+        this.left = left;
+        this.center = center;
+        this.left_offset = left_offset;
+        this.bottom_offset = bottom_offset;
+        this.right_offset = right_offset;
+        this.top_offset = top_offset;
 
-	public final void render(float x, float y, int width, int height, int type) {
-		int center_width = width - left_width - right_width;
-		int center_height = height - bottom_height - top_height;
-		left_bottom[type].render(x, y);
-		bottom[type].render(x + left_width, y, center_width, bottom_height);
-		right_bottom[type].render(x + left_width + center_width, y);
-		right[type].render(x + left_width + center_width, y + bottom_height, right_width, center_height);
-		right_top[type].render(x + left_width + center_width, y + bottom_height + center_height);
-		top[type].render(x + left_width, y + bottom_height + center_height, center_width, top_height);
-		left_top[type].render(x, y + bottom_height + center_height);
-		left[type].render(x, y + bottom_height, left_width, center_height);
-		center[type].render(x + left_width, y + bottom_height, center_width, center_height);
-	}
+        left_width = left[Skin.NORMAL].getWidth();
+        right_width = right[Skin.NORMAL].getWidth();
+        bottom_height = bottom[Skin.NORMAL].getHeight();
+        top_height = top[Skin.NORMAL].getHeight();
+    }
 
-	public final int getLeftOffset() {
-		return left_offset;
-	}
+    public final void render(float x, float y, int width, int height, int type) {
+        int center_width = width - left_width - right_width;
+        int center_height = height - bottom_height - top_height;
+        left_bottom[type].render(x, y);
+        bottom[type].render(x + left_width, y, center_width, bottom_height);
+        right_bottom[type].render(x + left_width + center_width, y);
+        right[type].render(x + left_width + center_width, y + bottom_height, right_width, center_height);
+        right_top[type].render(x + left_width + center_width, y + bottom_height + center_height);
+        top[type].render(x + left_width, y + bottom_height + center_height, center_width, top_height);
+        left_top[type].render(x, y + bottom_height + center_height);
+        left[type].render(x, y + bottom_height, left_width, center_height);
+        center[type].render(x + left_width, y + bottom_height, center_width, center_height);
+    }
 
-	public final int getBottomOffset() {
-		return bottom_offset;
-	}
+    public final int getLeftOffset() {
+        return left_offset;
+    }
 
-	public final int getRightOffset() {
-		return right_offset;
-	}
+    public final int getBottomOffset() {
+        return bottom_offset;
+    }
 
-	public final int getTopOffset() {
-		return top_offset;
-	}
+    public final int getRightOffset() {
+        return right_offset;
+    }
 
-		/**
-	 * Renders a solid color rectangle for highlights (e.g., text selection).
-	 * @param x left position
-	 * @param y top position
-	 * @param width rectangle width
-	 * @param height rectangle height
-	 * @param r red (0-1)
-	 * @param g green (0-1)
-	 * @param b blue (0-1)
-	 * @param a alpha (0-1)
-	 */
-	public void renderHighlight(float x, float y, int width, int height) {
-		// Use the center quad for highlight rendering, set alpha if supported
-		if (center != null && center.length > 0 && center[Skin.NORMAL] != null) {
-			center[Skin.NORMAL].render(x, y, width, height);
-		}
-	}
+    public final int getTopOffset() {
+        return top_offset;
+    }
+
+    /**
+     * Renders a solid color rectangle for highlights (e.g., text selection),
+     * ensuring the highlight is clipped to the visible region of the box.
+     *
+     * @param x The left position of the highlight rectangle (in box
+     * coordinates).
+     * @param y The top position of the highlight rectangle (in box
+     * coordinates).
+     * @param width The width of the highlight rectangle.
+     * @param height The height of the highlight rectangle.
+     * @param clip_left The minimum x value (left edge) to render the highlight
+     * (clipping region).
+     * @param clip_right The maximum x value (right edge) to render the
+     * highlight (clipping region).
+     * @param clip_bottom The minimum y value (bottom edge) to render the
+     * highlight (clipping region).
+     * @param clip_top The maximum y value (top edge) to render the highlight
+     * (clipping region).
+     *
+     * The highlight rectangle will be clamped so it does not extend outside the
+     * clipping region.
+     */
+    public void renderHighlight(float x, float y, int width, int height, float clip_left, float clip_right, float clip_bottom, float clip_top) {
+        float highlightLeft = Math.max(x, clip_left);
+        float highlightRight = Math.min(x + width, clip_right);
+        float highlightBottom = Math.max(y, clip_bottom);
+        float highlightTop = Math.min(y + height, clip_top);
+
+        float clampedWidth = highlightRight - highlightLeft;
+        float clampedHeight = highlightTop - highlightBottom;
+
+        if (clampedWidth > 0 && clampedHeight > 0 && center != null && center.length > 0 && center[Skin.NORMAL] != null) {
+            center[Skin.NORMAL].render(highlightLeft, highlightBottom, (int) clampedWidth, (int) clampedHeight);
+        }
+    }
 }

--- a/tt/classes/com/oddlabs/tt/gui/EditLine.java
+++ b/tt/classes/com/oddlabs/tt/gui/EditLine.java
@@ -1,222 +1,401 @@
 package com.oddlabs.tt.gui;
 
+import com.oddlabs.tt.event.LocalEventQueue;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.lwjgl.input.Keyboard;
-
+import org.lwjgl.Sys;
 import com.oddlabs.tt.font.Index;
 import com.oddlabs.tt.font.TextLineRenderer;
 import com.oddlabs.tt.guievent.EnterListener;
+import javax.swing.plaf.basic.BasicSplitPaneUI;
 
 public strictfp class EditLine extends TextField {
-	public final static int RIGHT_ALIGNED = 1;
-	public final static int LEFT_ALIGNED = 2;
-	
-	private final List enter_listeners = new ArrayList();
-	private final int alignment;
-	private final String allowed_chars;
-	private final int max_text_width;
 
-	private TextLineRenderer text_renderer;
-	private int offset_x;
-	private int index;
+    public final static int RIGHT_ALIGNED = 1;
+    public final static int LEFT_ALIGNED = 2;
+    private int selectionStart = -1;
+    private int selectionEnd = -1;
+    private final List enter_listeners = new ArrayList();
+    private final int alignment;
+    private final String allowed_chars;
+    private final int max_text_width;
 
-	public EditLine(int width, int max_chars) {
-		this(width, max_chars, LEFT_ALIGNED);
-	}
+    private TextLineRenderer text_renderer;
+    private int offset_x;
+    private int index;
 
-	public EditLine(int width, int max_chars, int alignment) {
-		this(width, max_chars, null, alignment);
-	}
+    public EditLine(int width, int max_chars) {
+        this(width, max_chars, LEFT_ALIGNED);
+    }
 
-	public EditLine(int width, int max_chars, String allowed_chars, int alignment) {
-		super(Skin.getSkin().getEditFont(), max_chars);
-		this.allowed_chars = allowed_chars;
-		this.alignment = alignment;
-		Box edit_box = Skin.getSkin().getEditBox();
-		setDim(width, getFont().getHeight() + edit_box.getBottomOffset() + edit_box.getTopOffset());
-		setCanFocus(true);
-		text_renderer = new TextLineRenderer(getFont()); 
-		this.max_text_width = width - edit_box.getLeftOffset() - edit_box.getRightOffset();
-		clear();
-	}
+    public EditLine(int width, int max_chars, int alignment) {
+        this(width, max_chars, null, alignment);
+    }
 
-	protected final int getCursorIndex() {
-		return GUIRoot.CURSOR_TEXT;
-	}
+    public EditLine(int width, int max_chars, String allowed_chars, int alignment) {
+        super(Skin.getSkin().getEditFont(), max_chars);
+        this.allowed_chars = allowed_chars;
+        this.alignment = alignment;
+        Box edit_box = Skin.getSkin().getEditBox();
+        setDim(width, getFont().getHeight() + edit_box.getBottomOffset() + edit_box.getTopOffset());
+        setCanFocus(true);
+        text_renderer = new TextLineRenderer(getFont());
+        this.max_text_width = width - edit_box.getLeftOffset() - edit_box.getRightOffset();
+        clear();
+    }
 
-	protected void renderGeometry(float clip_left, float clip_right, float clip_bottom, float clip_top) {
-		Box edit_box = Skin.getSkin().getEditBox();
-		if (isDisabled())
-			edit_box.render(0, 0, getWidth(), getHeight(), Skin.DISABLED);
-		else
-			edit_box.render(0, 0, getWidth(), getHeight(), Skin.NORMAL);
-		int render_index = isActive() ? index : -1;
-		renderText(text_renderer, edit_box.getLeftOffset(), edit_box.getBottomOffset(), offset_x, clip_left, clip_right, clip_bottom, clip_top, render_index);
-	}
+    protected final int getCursorIndex() {
+        return GUIRoot.CURSOR_TEXT;
+    }
 
-	protected void renderText(TextLineRenderer text_renderer, int x, int y, int offset_x, float clip_left, float clip_right, float clip_bottom, float clip_top, int render_index) {
-		clip_left = StrictMath.max(clip_left, x);
-		clip_right = StrictMath.min(clip_right, x + max_text_width);
-		text_renderer.render(x, y, offset_x, clip_left, clip_right, clip_bottom, clip_top, getText(), render_index);
-	}
+    protected void renderGeometry(float clip_left, float clip_right, float clip_bottom, float clip_top) {
+        Box edit_box = Skin.getSkin().getEditBox();
+        if (isDisabled()) {
+            edit_box.render(0, 0, getWidth(), getHeight(), Skin.DISABLED);
+        } else {
+            edit_box.render(0, 0, getWidth(), getHeight(), Skin.NORMAL);
+        }
+        int render_index = isActive() ? index : -1;
+        renderText(text_renderer, edit_box.getLeftOffset(), edit_box.getBottomOffset(), offset_x, clip_left, clip_right, clip_bottom, clip_top, render_index);
+    }
 
-	protected void keyReleased(KeyboardEvent event) {
-		switch (event.getKeyCode()) {
-			case Keyboard.KEY_RETURN:
-				enterPressedAll();
-				break;
-			default:
-				super.keyReleased(event);
-				break;
-		}
-	}
+    protected void renderText(TextLineRenderer text_renderer, int x, int y, int offset_x, float clip_left, float clip_right, float clip_bottom, float clip_top, int render_index) {
+        clip_left = StrictMath.max(clip_left, x);
+        clip_right = StrictMath.min(clip_right, x + max_text_width);
+        text_renderer.render(x, y, offset_x, clip_left, clip_right, clip_bottom, clip_top, getText(), render_index);
 
-	protected void keyRepeat(KeyboardEvent event) {
-		switch (event.getKeyCode()) {
-			case Keyboard.KEY_BACK:
-				if (index > 0) {
-					index--;
-					if (alignment == RIGHT_ALIGNED) {
-						char key = getText().charAt(index);
-						offset_x += (getFont().getQuad(key).getWidth() - getFont().getXBorder());
-					}
-					delete(index);
-				}
-				break;
-			case Keyboard.KEY_DELETE:
-				if (index < getText().length()) {
-					if (alignment == RIGHT_ALIGNED) {
-						char key = getText().charAt(index);
-						offset_x += (getFont().getQuad(key).getWidth() - getFont().getXBorder());
-					}
-					delete(index);
-				}
-				break;
-			case Keyboard.KEY_LEFT:
-				if (index > 0)
-					index--;
-				break;
-			case Keyboard.KEY_RIGHT:
-				if (index < getText().length())
-					index++;
-				break;
-			case Keyboard.KEY_HOME:
-				index = 0;
-				break;
-			case Keyboard.KEY_END:
-				index = getText().length();
-				break;
-			case Keyboard.KEY_TAB:
-			case Keyboard.KEY_RETURN:
-				super.keyRepeat(event);
-				break;
-			default:
-				char key = event.getKeyChar();
-				if (isAllowed(key)) {
-					boolean result = insert(index, key);
-					assert result;
-					index++;
-					if (alignment == RIGHT_ALIGNED)
-						offset_x -= (getFont().getQuad(key).getWidth() - getFont().getXBorder());
-				} else {
-					super.keyRepeat(event);
-				}
-				break;
-		}
-		correctOffsetX();
-	}
+        renderHighlight(text_renderer, x, y, offset_x);
+    }
 
-	public final boolean isAllowed(char ch) {
-		return super.isAllowed(ch) && getFont().getQuad(ch) != null && (allowed_chars == null || allowed_chars.indexOf(ch) != -1);
-	}
-	
-	private final void correctOffsetX() {
-		Box edit_box = Skin.getSkin().getEditBox();
-		int index_render_x = text_renderer.getIndexRenderX(edit_box.getLeftOffset(),
-										   edit_box.getBottomOffset(),
-										   offset_x,
-										   getText(),
-										   index);
+    /**
+     * Renders the text highlight for the selected text by using the selectionStart and selectionEnd values.
+     * @param text_renderer The text line renderer - to calculate the highlight positions.
+     * @param x The x position.
+     * @param y The y position.
+     * @param offset_x The x offset for highlight to start in the box
+     */
+    private void renderHighlight(TextLineRenderer text_renderer, int x, int y, int offset_x) {
+        if (selectionStart != -1 && selectionEnd != -1 && selectionStart != selectionEnd) {
+            int selStartX = text_renderer.getIndexRenderX(x, y, offset_x, getText(), selectionStart);
+            int selEndX = text_renderer.getIndexRenderX(x, y, offset_x, getText(), selectionEnd);
+            int highlightLeft = Math.min(selStartX, selEndX);
+            int highlightRight = Math.max(selStartX, selEndX);
+            Skin.getSkin().getEditBox().renderHighlight(highlightLeft, y, highlightRight - highlightLeft, getFont().getHeight());
+        }
+    }
 
-		int max_x = computeMaxX();
-		if (index_render_x > max_x) {
-			offset_x -= index_render_x - max_x;
-		} else if (index_render_x < edit_box.getLeftOffset()) {
-			offset_x += edit_box.getLeftOffset() - index_render_x;
-		}
-	}
+    @Override
+    protected void keyReleased(KeyboardEvent event) {
+        switch (event.getKeyCode()) {
+            case Keyboard.KEY_RETURN:
+                enterPressedAll();
+                break;
+            default:
+                super.keyReleased(event);
+                break;
+        }
+    }
 
-	private final int computeMaxX() {
-		Box edit_box = Skin.getSkin().getEditBox();
-		return getWidth() - edit_box.getRightOffset() - Index.INDEX_WIDTH/* - getFont().getXBorder()/2*/;
-	}
+    @Override
+    protected void keyRepeat(KeyboardEvent event) {
+        switch (event.getKeyCode()) {
+            case Keyboard.KEY_BACK:
+                // Selection deletion is handled in doShiftModifier()
+                if (index > 0 && selectionStart == -1 && selectionEnd == -1) {
+                    index--;
+                    if (alignment == RIGHT_ALIGNED) {
+                        char key = getText().charAt(index);
+                        offset_x += (getFont().getQuad(key).getWidth() - getFont().getXBorder());
+                    }
+                    delete(index);
+                }
+                break;
+            case Keyboard.KEY_DELETE:
+                // Selection deletion is handled in doShiftModifier()
+                if (index < getText().length() && selectionStart == -1 && selectionEnd == -1) {
+                    if (alignment == RIGHT_ALIGNED) {
+                        char key = getText().charAt(index);
+                        offset_x += (getFont().getQuad(key).getWidth() - getFont().getXBorder());
+                    }
+                    delete(index);
+                }
+                break;
+            case Keyboard.KEY_LEFT:
+                if (index > 0) {
+                    index--;
+                }
+                break;
+            case Keyboard.KEY_RIGHT:
+                if (index < getText().length()) {
+                    index++;
+                }
+                break;
+            case Keyboard.KEY_HOME:
+                index = 0;
+                break;
+            case Keyboard.KEY_END:
+                index = getText().length();
+                break;
+            case Keyboard.KEY_TAB:
+            case Keyboard.KEY_RETURN:
+                super.keyRepeat(event);
+                break;
+            default:
+                char key = event.getKeyChar();
+                if (isAllowed(key)) {
+                    boolean result = insert(index, key);
+                    assert result;
+                    index++;
+                    if (alignment == RIGHT_ALIGNED) {
+                        offset_x -= (getFont().getQuad(key).getWidth() - getFont().getXBorder());
+                    }
+                } else {
+                    super.keyRepeat(event);
+                }
+                break;
+        }
+        if (doControlModifier(event)) {
+            return;
+        } // Highlight text
+        else if (doShiftModifier(event)) {
+            return;
+        }
+        correctOffsetX();
+    }
 
-	public final int getIndex() {
-		return index;
-	}
+    public final boolean isAllowed(char ch) {
+        return super.isAllowed(ch) && getFont().getQuad(ch) != null && (allowed_chars == null || allowed_chars.indexOf(ch) != -1);
+    }
 
-	public final void setIndex(int index) {
-		this.index = index;
-	}
+    private final void correctOffsetX() {
+        Box edit_box = Skin.getSkin().getEditBox();
+        int index_render_x = text_renderer.getIndexRenderX(edit_box.getLeftOffset(),
+                edit_box.getBottomOffset(),
+                offset_x,
+                getText(),
+                index);
 
-	public final void clear() {
-		super.clear();
-		index = 0;
-		if (alignment == LEFT_ALIGNED)
-			offset_x = -getFont().getXBorder()/2;
-		else {
-			int text_width = Skin.getSkin().getEditFont().getWidth(getText());
-			offset_x = max_text_width - text_width - Index.INDEX_WIDTH - getFont().getXBorder()/2;
-		}
-	}
+        int max_x = computeMaxX();
+        if (index_render_x > max_x) {
+            offset_x -= index_render_x - max_x;
+        } else if (index_render_x < edit_box.getLeftOffset()) {
+            offset_x += edit_box.getLeftOffset() - index_render_x;
+        }
+    }
 
-	protected final void appendNotify(CharSequence str) {
-		if (alignment == RIGHT_ALIGNED) {
-			for (int i = 0; i < str.length(); i++) {
-				char key = str.charAt(i);
-				offset_x -= (getFont().getQuad(key).getWidth() - getFont().getXBorder());
-			}
-		}
-	}
+    private final int computeMaxX() {
+        Box edit_box = Skin.getSkin().getEditBox();
+        return getWidth() - edit_box.getRightOffset() - Index.INDEX_WIDTH/* - getFont().getXBorder()/2*/;
+    }
 
-	protected void focusNotify(boolean focus) {
-		if (focus)
-			index = getText().length();
-	}
+    public final int getIndex() {
+        return index;
+    }
 
-	protected final void mouseEntered() {
-	}
+    /**
+     * Sets the index aka the cursor position to the given value
+     */
+    public final void setIndex(int index) {
+        this.index = index;
+    }
 
-	protected final void mouseExited() {
-	}
+    public final void clear() {
+        super.clear();
+        index = 0;
+        if (alignment == LEFT_ALIGNED) {
+            offset_x = -getFont().getXBorder() / 2;
+        } else {
+            int text_width = Skin.getSkin().getEditFont().getWidth(getText());
+            offset_x = max_text_width - text_width - Index.INDEX_WIDTH - getFont().getXBorder() / 2;
+        }
+    }
 
-	protected final void mousePressed(int button, int x, int y) {
-		if (button == LocalInput.LEFT_BUTTON) {
-			Box edit_box = Skin.getSkin().getEditBox();
-			index = text_renderer.jumpDirect(edit_box.getLeftOffset() + offset_x,
-											 edit_box.getBottomOffset(),
-											 x,
-											 getText(),
-											 index);
-		}
-	}
+    protected final void appendNotify(CharSequence str) {
+        if (alignment == RIGHT_ALIGNED) {
+            for (int i = 0; i < str.length(); i++) {
+                char key = str.charAt(i);
+                offset_x -= (getFont().getQuad(key).getWidth() - getFont().getXBorder());
+            }
+        }
+    }
 
-	public final void enterPressedAll() {
-		CharSequence text = getText();
-		enterPressed(text);
-		for (int i = 0; i < enter_listeners.size(); i++) {
-			EnterListener listener = (EnterListener)enter_listeners.get(i);
-			if (listener != null)
-				listener.enterPressed(text);
-		}
-	}
+    protected void focusNotify(boolean focus) {
+        if (focus) {
+            index = getText().length();
+        }
+    }
 
-	protected void enterPressed(CharSequence text) {
-	}
+    protected final void mouseEntered() {
+    }
 
-	public final void addEnterListener(EnterListener listener) {
-		enter_listeners.add(listener);
-	}
+    protected final void mouseExited() {
+    }
+
+    protected final void mousePressed(int button, int x, int y) {
+        if (button == LocalInput.LEFT_BUTTON) {
+            Box edit_box = Skin.getSkin().getEditBox();
+            index = text_renderer.jumpDirect(edit_box.getLeftOffset() + offset_x,
+                    edit_box.getBottomOffset(),
+                    x,
+                    getText(),
+                    index);
+        }
+    }
+
+    public final void enterPressedAll() {
+        CharSequence text = getText();
+        enterPressed(text);
+        for (int i = 0; i < enter_listeners.size(); i++) {
+            EnterListener listener = (EnterListener) enter_listeners.get(i);
+            if (listener != null) {
+                listener.enterPressed(text);
+            }
+        }
+    }
+
+    protected void enterPressed(CharSequence text) {
+    }
+
+    public final void addEnterListener(EnterListener listener) {
+        enter_listeners.add(listener);
+    }
+
+    private boolean doControlModifier(KeyboardEvent event) {
+        if (LocalInput.isControlDownCurrently() && event.getKeyCode() == Keyboard.KEY_V) {
+            String clipboard = (String) LocalEventQueue.getQueue().getDeterministic().log(Sys.getClipboard());
+            if (clipboard != null) {
+                String beforeCursorString = getContents().substring(0, getIndex());
+                String afterCursorString = getContents().substring(getIndex());
+                set(beforeCursorString + clipboard + afterCursorString);
+                setIndex(beforeCursorString.length() + clipboard.length());
+                return true;
+            }
+        } // Highlight text
+        return false;
+    }
+
+    private boolean doShiftModifier(KeyboardEvent event) {
+        if (LocalInput.isShiftDownCurrently() && event.getKeyCode() == Keyboard.KEY_RIGHT && (selectionEnd < getContents().length() || selectionEnd == -1)) {
+            // First time shift is pressed and cursor has moved
+            if (selectionStart == -1) {
+                selectionStart = getIndex() - 1;
+                selectionEnd = getIndex();
+            } else {
+                // when right is pressed the selection moves 1 to the right by the time we are evaluating this
+                // other inputs are processed before mofifier keys at the moment
+                if (getIndex() <= selectionStart + 1) {
+                    selectionStart++;
+                } else {
+                    selectionEnd++;
+                }
+            }
+
+            if (selectionStart >= getContents().length()) {
+                selectionStart = getContents().length();
+            }
+            if (selectionEnd >= getContents().length()) {
+                selectionEnd = getContents().length();
+            }
+            return true;
+        } else if (LocalInput.isShiftDownCurrently() && event.getKeyCode() == Keyboard.KEY_LEFT && (selectionStart > 0 || selectionStart == -1)) {
+            // First time shift is pressed and the cursor has moved
+            if (selectionStart == -1) {
+                selectionStart = getIndex();
+                if (selectionStart < 0) {
+                    selectionStart = 0;
+                }
+                selectionEnd = getIndex() + 1;
+            } else {
+                // cursor is at start of selection
+                if (getIndex() < selectionStart) {
+                    selectionStart--;
+                } else {
+                    selectionEnd--;
+                }
+            }
+
+            if (selectionEnd < 0) {
+                selectionEnd = 0;
+            }
+            if (selectionStart < 0) {
+                selectionStart = 0;
+            }
+            return true;
+        } else if (selectionStart != -1 && selectionEnd != -1
+                && (event.getKeyChar() != '\0'
+                || event.getKeyCode() == Keyboard.KEY_DELETE
+                || event.getKeyCode() == Keyboard.KEY_BACK)) {
+            System.out.println("Key Pressed: " + event.getKeyChar());
+            // Everything up to the selection
+            String beforeReplace;
+            if (event.getKeyCode() != Keyboard.KEY_BACK && event.getKeyCode() != Keyboard.KEY_DELETE) {                
+                beforeReplace = getContents().substring(0, selectionStart) + event.getKeyChar();
+            } else {
+                beforeReplace = getContents().substring(0, selectionStart);
+            }
+            String afterReplace = getContents().substring(beforeReplace.length() + (selectionEnd - selectionStart), getContents().length());
+            String newContent = beforeReplace + afterReplace;
+
+            // System.out.println("beforeReplace: '" + beforeReplace + "'");
+            // System.out.println("afterReplace: '" + afterReplace + "'");
+            // System.out.println("newContent: '" + newContent + "'");
+            // resets the cursor index to 0
+            
+            set(newContent);
+
+            // indexing needs to be adjusted based on if a new key is typed or backspace/delete is hit
+            if (event.getKeyCode() == Keyboard.KEY_BACK || event.getKeyCode() == Keyboard.KEY_DELETE) {
+                // Sets the cursor after the replaced content
+                if (newContent.length() == 0) {
+                    setIndex(0);
+                } else {
+
+                    // If we're in the middle of the text, keep the cursor at the start of the replaced section
+                    setIndex(beforeReplace.length());
+
+                    if (index > newContent.length()) {
+                        setIndex(newContent.length());
+                    }
+                }
+            } else {
+                setIndex(beforeReplace.length());
+            }
+
+            selectionStart = -1;
+            selectionEnd = -1;
+        } // unhighlight if the cursor moves without shift
+        else if (!LocalInput.isShiftDownCurrently() && (event.getKeyCode() == Keyboard.KEY_LEFT || event.getKeyCode() == Keyboard.KEY_RIGHT) 
+                        && (selectionStart != -1 || selectionEnd != -1)) {
+            // Clear selection if shift is not down and the key pressed is not left/right
+            if(event.getKeyCode() == Keyboard.KEY_LEFT) {
+                setIndex(selectionStart);   
+            }
+            else if(event.getKeyCode() == Keyboard.KEY_RIGHT) {
+                setIndex(selectionEnd);
+            }
+            selectionStart = -1;
+            selectionEnd = -1;            
+        }
+
+        return false;
+    }
+    /** TODO: Can we move this to a static function in Utils? It has basically the same logic used in two places now */
+    private final void pasteClipboard(String contents) {
+        contents = contents.trim();
+        clear();
+
+        StringBuffer append_buffer = new StringBuffer();
+        for (int i = 0; i < contents.length(); i++) {
+            char c = contents.charAt(i);
+            if (this.isAllowed(c)) {
+                append_buffer.append(c);
+            }
+        }
+        this.append(append_buffer);
+        // Sets the cursor
+        setIndex(getContents().length());
+    }
+
 }

--- a/tt/classes/com/oddlabs/tt/gui/EditLine.java
+++ b/tt/classes/com/oddlabs/tt/gui/EditLine.java
@@ -66,9 +66,8 @@ public strictfp class EditLine extends TextField {
     protected void renderText(TextLineRenderer text_renderer, int x, int y, int offset_x, float clip_left, float clip_right, float clip_bottom, float clip_top, int render_index) {
         clip_left = StrictMath.max(clip_left, x);
         clip_right = StrictMath.min(clip_right, x + max_text_width);
-        text_renderer.render(x, y, offset_x, clip_left, clip_right, clip_bottom, clip_top, getText(), render_index);
-
-        renderHighlight(text_renderer, x, y, offset_x);
+        text_renderer.render(x, y, offset_x, clip_left, clip_right, clip_bottom, clip_top, getText(), render_index);        
+        renderHighlight(text_renderer, x, y, offset_x, clip_left, clip_right, clip_bottom, clip_top);   
     }
 
     /**
@@ -81,13 +80,13 @@ public strictfp class EditLine extends TextField {
      * @param y The y position.
      * @param offset_x The x offset for highlight to start in the box
      */
-    private void renderHighlight(TextLineRenderer text_renderer, int x, int y, int offset_x) {
+    private void renderHighlight(TextLineRenderer text_renderer, int x, int y, int offset_x, float clip_left, float clip_right, float clip_bottom, float clip_top) {
         if (selectionStart != -1 && selectionEnd != -1 && selectionStart != selectionEnd) {
             int selStartX = text_renderer.getIndexRenderX(x, y, offset_x, getText(), selectionStart);
             int selEndX = text_renderer.getIndexRenderX(x, y, offset_x, getText(), selectionEnd);
             int highlightLeft = Math.min(selStartX, selEndX);
-            int highlightRight = Math.max(selStartX, selEndX);
-            Skin.getSkin().getEditBox().renderHighlight(highlightLeft, y, highlightRight - highlightLeft, getFont().getHeight());
+            int highlightRight = Math.max(selStartX, selEndX);            
+            Skin.getSkin().getEditBox().renderHighlight(highlightLeft, y, highlightRight - highlightLeft, getFont().getHeight(), clip_left, clip_right, clip_bottom, clip_top);
         }
     }
 
@@ -162,9 +161,11 @@ public strictfp class EditLine extends TextField {
                 break;
         }
         if (doControlModifier(event)) {
+            correctOffsetX();
             return;
         } // Highlight text
         else if (doShiftModifier(event)) {
+            correctOffsetX();
             return;
         }
         correctOffsetX();

--- a/tt/classes/com/oddlabs/tt/gui/EditLine.java
+++ b/tt/classes/com/oddlabs/tt/gui/EditLine.java
@@ -152,6 +152,10 @@ public strictfp class EditLine extends TextField {
             case Keyboard.KEY_RETURN:
                 super.keyRepeat(event);
                 break;
+            case Keyboard.KEY_ESCAPE:
+                selectionStart = -1;
+                selectionEnd = -1;
+                break;
             default:
                 char key = event.getKeyChar();
                 if (isAllowed(key)) {
@@ -247,6 +251,11 @@ public strictfp class EditLine extends TextField {
 
     protected final void mousePressed(int button, int x, int y) {
         if (button == LocalInput.LEFT_BUTTON) {
+            if(this.selectionStart != -1 && this.selectionEnd != -1) {
+                this.selectionStart = -1;
+                this.selectionEnd = -1;
+            }
+            
             Box edit_box = Skin.getSkin().getEditBox();
             index = text_renderer.jumpDirect(edit_box.getLeftOffset() + offset_x,
                     edit_box.getBottomOffset(),

--- a/tt/classes/com/oddlabs/tt/gui/EditLine.java
+++ b/tt/classes/com/oddlabs/tt/gui/EditLine.java
@@ -287,13 +287,23 @@ public strictfp class EditLine extends TextField {
 
     private void pasteClipboard() {
         String clipboard = (String) LocalEventQueue.getQueue().getDeterministic().log(Sys.getClipboard());
-        if (clipboard != null) {
+        if (clipboard != null) {            
+            for (char item : clipboard.toCharArray()) {
+                if (!isAllowed(item)) {
+                    return;
+                }
+            }
+
             if (selectionStart != -1 && selectionEnd != -1 && selectionStart != selectionEnd) {
                 // delete the selected text first
                 String beforeReplace = getContents().substring(0, selectionStart);
                 String afterReplace = getContents().substring(beforeReplace.length() + (selectionEnd - selectionStart), getContents().length());
-                set(beforeReplace + clipboard + afterReplace);
-                // Set cursor after the pasted content                
+                String newContent = beforeReplace + clipboard + afterReplace;
+                if(newContent.length() > max_chars) {
+                    return;
+                }
+                set(newContent);
+                // Set cursor after the pasted content
                 setIndex(beforeReplace.length() + clipboard.length());
                 // Clear selection
                 selectionStart = -1;
@@ -301,7 +311,11 @@ public strictfp class EditLine extends TextField {
             } else {
                 String beforeCursorString = getContents().substring(0, getIndex());
                 String afterCursorString = getContents().substring(getIndex());
-                set(beforeCursorString + clipboard + afterCursorString);
+                String newContent = beforeCursorString + clipboard + afterCursorString;
+                if(newContent.length() > max_chars) {
+                    return;
+                }
+                set(newContent);
                 setIndex(beforeCursorString.length() + clipboard.length());
             }
         }
@@ -368,8 +382,6 @@ public strictfp class EditLine extends TextField {
                 && (event.getKeyChar() != '\0'
                 || event.getKeyCode() == Keyboard.KEY_DELETE
                 || event.getKeyCode() == Keyboard.KEY_BACK)) {
-            System.out.println("Key Pressed: " + event.getKeyChar());
-            // Everything up to the selection
             String beforeReplace;
             if (event.getKeyCode() != Keyboard.KEY_BACK && event.getKeyCode() != Keyboard.KEY_DELETE) {
                 beforeReplace = getContents().substring(0, selectionStart) + event.getKeyChar();

--- a/tt/classes/com/oddlabs/tt/gui/EditLine.java
+++ b/tt/classes/com/oddlabs/tt/gui/EditLine.java
@@ -264,16 +264,33 @@ public strictfp class EditLine extends TextField {
 
     private boolean doControlModifier(KeyboardEvent event) {
         if (LocalInput.isControlDownCurrently() && event.getKeyCode() == Keyboard.KEY_V) {
-            String clipboard = (String) LocalEventQueue.getQueue().getDeterministic().log(Sys.getClipboard());
-            if (clipboard != null) {
+            pasteClipboard();
+            return true;
+        } // Highlight text
+        return false;
+    }
+
+    private void pasteClipboard() {
+        String clipboard = (String) LocalEventQueue.getQueue().getDeterministic().log(Sys.getClipboard());
+        if (clipboard != null) {
+            if(selectionStart != -1 && selectionEnd != -1 && selectionStart != selectionEnd) {
+                // delete the selected text first
+                String beforeReplace = getContents().substring(0, selectionStart);
+                String afterReplace = getContents().substring(beforeReplace.length() + (selectionEnd - selectionStart), getContents().length());
+                set(beforeReplace + clipboard + afterReplace);
+                // Set cursor after the pasted content                
+                setIndex(beforeReplace.length() + clipboard.length());
+                // Clear selection
+                selectionStart = -1;
+                selectionEnd = -1;
+            }
+            else {
                 String beforeCursorString = getContents().substring(0, getIndex());
                 String afterCursorString = getContents().substring(getIndex());
                 set(beforeCursorString + clipboard + afterCursorString);
                 setIndex(beforeCursorString.length() + clipboard.length());
-                return true;
             }
-        } // Highlight text
-        return false;
+        }
     }
 
     private boolean doShiftModifier(KeyboardEvent event) {
@@ -381,21 +398,4 @@ public strictfp class EditLine extends TextField {
 
         return false;
     }
-    /** TODO: Can we move this to a static function in Utils? It has basically the same logic used in two places now */
-    private final void pasteClipboard(String contents) {
-        contents = contents.trim();
-        clear();
-
-        StringBuffer append_buffer = new StringBuffer();
-        for (int i = 0; i < contents.length(); i++) {
-            char c = contents.charAt(i);
-            if (this.isAllowed(c)) {
-                append_buffer.append(c);
-            }
-        }
-        this.append(append_buffer);
-        // Sets the cursor
-        setIndex(getContents().length());
-    }
-
 }

--- a/tt/classes/com/oddlabs/tt/gui/EditLine.java
+++ b/tt/classes/com/oddlabs/tt/gui/EditLine.java
@@ -251,11 +251,11 @@ public strictfp class EditLine extends TextField {
 
     protected final void mousePressed(int button, int x, int y) {
         if (button == LocalInput.LEFT_BUTTON) {
-            if(this.selectionStart != -1 && this.selectionEnd != -1) {
+            if (this.selectionStart != -1 && this.selectionEnd != -1) {
                 this.selectionStart = -1;
                 this.selectionEnd = -1;
             }
-            
+
             Box edit_box = Skin.getSkin().getEditBox();
             index = text_renderer.jumpDirect(edit_box.getLeftOffset() + offset_x,
                     edit_box.getBottomOffset(),
@@ -347,7 +347,54 @@ public strictfp class EditLine extends TextField {
     }
 
     private boolean doShiftModifier(KeyboardEvent event) {
-        if (LocalInput.isShiftDownCurrently() && event.getKeyCode() == Keyboard.KEY_HOME) {
+        // TODO: Same but for ctrl
+        if (LocalInput.isShiftDownCurrently() && LocalInput.isControlDownCurrently() && event.getKeyCode() == Keyboard.KEY_LEFT) {
+            // WORD selection to the left
+            String contents = getContents();
+            if (getIndex() == 0) {
+                return true;
+            }
+            // cursor at start of selection / no selection
+            // select until a space is seen
+            // if a space is seen immediately select until the next space
+            // if start of line is then just keep cursor and selection
+            System.out.println("Selecting word to the left");
+            boolean isCursorAtStartOfSelection = getIndex() <= selectionStart || selectionStart == -1;
+            int startingIndex = getIndex();
+
+            if (!isCursorAtStartOfSelection) {
+                startingIndex = selectionStart;
+            }
+
+            boolean characterBehindCursorIsSpace = contents.charAt(getIndex()) == ' ';
+
+            if (characterBehindCursorIsSpace) {
+                while (startingIndex > 0 && contents.charAt(startingIndex) == ' ') {
+                    startingIndex--;
+                }
+            }
+
+            boolean didLoop = false;
+            while (startingIndex >= 0 && contents.charAt(startingIndex) != ' ') {
+                didLoop = true;
+                startingIndex--;
+            }
+            // set the cursor back one since we went past the space
+            if (didLoop) {
+                startingIndex++;
+            }
+
+            if (selectionStart == -1) {
+                selectionStart = startingIndex;
+                selectionEnd = getIndex() + 1;
+            } else {
+                selectionStart = startingIndex;
+            }
+            setIndex(startingIndex);
+        } else if (LocalInput.isShiftDownCurrently() && LocalInput.isControlDownCurrently() && event.getKeyCode() == Keyboard.KEY_RIGHT) {
+            //  TODO: right word selection
+
+        } else if (LocalInput.isShiftDownCurrently() && event.getKeyCode() == Keyboard.KEY_HOME) {
             // curosr is at the start of selection
             // && left arrow key is pressed
             //  -> highlight to the start of the line including what is already highlighted
@@ -355,7 +402,7 @@ public strictfp class EditLine extends TextField {
             // && left arrow key is pressed
             // -> unhighlight highlight to the start of the line clearing current highlight
             boolean isCursorAtStartOfSelection = getIndex() <= selectionStart;
-            if(selectionStart == -1) {
+            if (selectionStart == -1) {
                 selectionStart = getIndex();
                 selectionEnd = getIndex();
             }
@@ -374,7 +421,7 @@ public strictfp class EditLine extends TextField {
             // && right arrow key is pressed
             //  -> highlight to the end of the line including what is already highlighted
             boolean isCursorAtStartOfSelection = getIndex() <= selectionStart;
-            if(selectionStart == -1) {
+            if (selectionStart == -1) {
                 selectionStart = getIndex();
                 selectionEnd = getIndex();
             }

--- a/tt/classes/com/oddlabs/tt/gui/TextField.java
+++ b/tt/classes/com/oddlabs/tt/gui/TextField.java
@@ -10,7 +10,7 @@ public abstract strictfp class TextField extends GUIObject implements CharSequen
 
 	private final StringBuffer text;
 	private final Font font;
-	private final int max_chars;
+	protected final int max_chars;
 
 	public TextField(Font font, int max_chars) {
 		this("", font, max_chars);


### PR DESCRIPTION
Current status on #3 


[X] = done
[ ] = not done

'selection' = highlighted text

- shift + right arrow key when selection exists
    -> cursor at the beginning of selection
        -> reduces highlighted text by increasing start selection [X]
    -> cursor at end of selection
        -> increases highlighted text by increasing end selection [X]

- shift + left arrow key when selection exists
    -> cursor at the beginning of selection
        -> increase highlighted text by decreasing the start selection [X]
    -> cursor at the end of the selection
        -> increase highlighted text by decreasing the end selection [X]


- shift not pressed + selection exists
    -> right arrow key pressed
        -> cursor moves to end of selection and selection is cleared [X]
    -> left arrow key pressed
        -> cursor moves to beginning of selection and selection is cleared [X]

- arrow keys pressed without shift and no selection
    -> left arrow key pressed
        -> cursor moves one to the left [X]
    -> right arrow key pressed
        -> cursor moves one to the right [X]

- selection exists + any non-special key pressed
    -> selection is cleared and replaced with pressed key [X]
    -> cursor moves to end of inserted key [X]

- selection exists + backspace pressed
    -> selection is cleared [X]
    -> cursor moves to beginning of selection [X]

- selection exists + delete pressed
    -> selection is cleared [X]
    -> cursor moves to beginning of selection [X]

- cursor at beginning of text + left arrow key pressed
    -> cursor remains at beginning of text [X]

- cursor at end of text + right arrow key pressed
    -> cursor remains at end of text [X]

- cursor at beginning of text + backspace pressed
    -> cursor remains at beginning of text [X]
    -> no text is modified [X]

-cursor at end of text + delete pressed
    -> cursor remains at end of text [X]
    -> no text is modified [X]

- shift held + left arrow key held
    -> selection expands left until beginning of text [X]

- shift held + right arrow key held
    -> selection expands right until end of text [X]

- selection + (paste / ctrl + v) pressed
    -> selection is replaced with pasted text [ ]
    -> cursor moves to end of pasted text [ ]




Other Tasks:
- Paste text (ctrl + v) [X]
- Copy text to clipboard (ctrl + c) [X]
- Cut text to clipboard (ctrl + x) [X]
- Select all text (ctrl + a) [X]
- Select using the mouse + shift () [ ]
- crtl + shift expands highlight text by word instead of by character when arrow keys are pressed [ ]

NTH
- selection + shift + up arrow key pressed
    -> highlights all text before selection and none of the currently selected text
    -> NOTE: same functionality as selection + home

- selection + shift + down arrow key pressed
    -> highlights all text after selection WITH all the currently selected text
    -> NOTE: same functionality as selection + end

known bugs:

- when everything is highlighted moving cursor left or right does not reduce the selection