### PR TITLE
Graphics settings

### DIFF
--- a/common/common.xml
+++ b/common/common.xml
@@ -163,7 +163,7 @@
 		<if>
 			<isset property="macosx.firstthread" />
 			<then>
-				<java fork="yes" classname="${main_class}">
+				<java fork="true" classname="${main_class}">
 					<classpath refid="_common.combined.run.classpath" />
 
 					<jvmarg value="-ea" />
@@ -179,7 +179,7 @@
 				</java>
 			</then>
 			<else>
-				<java fork="yes" classname="${main_class}">
+				<java fork="true" classname="${main_class}">
 					<classpath refid="_common.combined.run.classpath" />
 
 					<jvmarg value="-ea" />

--- a/tt/classes/com/oddlabs/tt/delegate/MainMenu.java
+++ b/tt/classes/com/oddlabs/tt/delegate/MainMenu.java
@@ -46,6 +46,8 @@ import com.oddlabs.tt.global.Globals;
 import com.oddlabs.tt.trigger.GameOverTrigger;
 import com.oddlabs.net.NetworkSelector;
 
+import com.oddlabs.tt.render.DisplayModel;
+
 public final strictfp class MainMenu extends Menu {
 	public MainMenu(NetworkSelector network, GUIRoot gui_root, Camera camera) {
 		super(network, gui_root, camera);
@@ -94,6 +96,11 @@ public final strictfp class MainMenu extends Menu {
 		addExitButton();
 
 		addBuyButton();
+
+		if(DisplayModel.getBadModeStatus()) {
+			addChild(new DisplayBadDetected());
+			DisplayModel.setBadModeStatus(false);
+		}
 
 		if (Network.getMatchmakingClient().isConnected()) {
 			new SelectGameMenu(getNetwork(), getGUIRoot(), this);

--- a/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
+++ b/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
@@ -407,8 +407,11 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
         }
     }
 
+    // Remember refreshrate listener to be able to remove it
+    RefreshrateListener refrateListener;
+
     private final void fetchRefreshRates() {
-        // Clear items and listeners
+        // Clear items
         pulldown_rr.clearItems();
         pulldown_rr.listListeners();
         int[] refreshRates = DisplayModel.getRefreshRates();
@@ -420,9 +423,11 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
             if (refreshRates[i] == curr_refreshrate)
                 selected_index = i;
         }
-        //FIXME: Memory leak, index error.
-        //TODO: Remove/replace listener
-        pulldown_rr.addItemChosenListener(new RefreshrateListener(selected_index, refreshRates));
+
+        // Remove refreshratelistener, recreate and attach.
+        pulldown_rr.removeItemChosenListener(refrateListener);
+        refrateListener = new RefreshrateListener(selected_index, refreshRates);
+        pulldown_rr.addItemChosenListener(refrateListener);
     }
 
     private final Group CreateRefreshrateSelect() {
@@ -440,7 +445,11 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
                 selected_index = i;
         }
         PulldownButton pulldownbtn_rr = new PulldownButton(gui_root, pulldown_rr, 100);
-        pulldown_rr.addItemChosenListener(new RefreshrateListener(selected_index, refreshRates));
+
+        // Create refresh rate listener
+        refrateListener = new RefreshrateListener(selected_index, refreshRates);
+        pulldown_rr.addItemChosenListener(refrateListener);
+        
         refreshrate_group.addChild(pulldownbtn_rr);
         label_rr.place();
         pulldownbtn_rr.place(label_rr, BOTTOM_LEFT);

--- a/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
+++ b/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
@@ -413,7 +413,7 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
     private final void fetchRefreshRates() {
         // Clear items
         pulldown_rr.clearItems();
-        pulldown_rr.listListeners();
+        
         int[] refreshRates = DisplayModel.getRefreshRates();
         int selected_index = 0;
         int curr_refreshrate = DisplayModel.getCurrentResolution().refreshRate();
@@ -449,7 +449,7 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
         // Create refresh rate listener
         refrateListener = new RefreshrateListener(selected_index, refreshRates);
         pulldown_rr.addItemChosenListener(refrateListener);
-        
+
         refreshrate_group.addChild(pulldownbtn_rr);
         label_rr.place();
         pulldownbtn_rr.place(label_rr, BOTTOM_LEFT);

--- a/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
+++ b/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
@@ -413,7 +413,7 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
     private final void fetchRefreshRates() {
         // Clear items
         pulldown_rr.clearItems();
-        
+
         int[] refreshRates = DisplayModel.getRefreshRates();
         int selected_index = 0;
         int curr_refreshrate = DisplayModel.getCurrentResolution().refreshRate();
@@ -691,6 +691,11 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
 
 		public final void rowChosen(Object o) {
 			mode = (DisplayModelItem)o;
+
+            //Get current refresh rate, set it to chosen mode
+            DisplayModelItem curr_mode = DisplayModel.getCurrentResolution();
+            mode.setRefreshRate(curr_mode.refreshRate());
+
 			DisplayModel.setCurrentResolution(mode);
             fetchRefreshRates();
             //DisplayChangeForm display_change_form = new DisplayChangeForm(this);
@@ -713,9 +718,15 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
         public RefreshrateListener(int index, int[] _refreshRates) {
             pulldown_rr.chooseItem(index);
             refreshRates = _refreshRates;
+
+            setRefreshRate(index);
         }
         public final void itemChosen(PulldownMenu menu, int item_index) {
-            int refreshRate = refreshRates[item_index];
+            setRefreshRate(item_index);
+        }
+
+        private final void setRefreshRate(int index) {
+            int refreshRate = refreshRates[index];
 
             DisplayModelItem curr_res = DisplayModel.getCurrentResolution();
             curr_res.setRefreshRate(refreshRate);

--- a/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
+++ b/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
@@ -2,7 +2,7 @@ package com.oddlabs.tt.form;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
-
+import java.util.List;
 import com.oddlabs.tt.render.Cursor;
 
 import com.oddlabs.matchmaking.Game;
@@ -407,6 +407,24 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
         }
     }
 
+    private final void fetchRefreshRates() {
+        // Clear items and listeners
+        pulldown_rr.clearItems();
+        pulldown_rr.listListeners();
+        int[] refreshRates = DisplayModel.getRefreshRates();
+        int selected_index = 0;
+        int curr_refreshrate = DisplayModel.getCurrentResolution().refreshRate();
+
+        for (int i = 0; i<refreshRates.length; i++) {
+            pulldown_rr.addItem(new PulldownItem(refreshRates[i] + " Hz"));
+            if (refreshRates[i] == curr_refreshrate)
+                selected_index = i;
+        }
+        //FIXME: Memory leak, index error.
+        //TODO: Remove/replace listener
+        pulldown_rr.addItemChosenListener(new RefreshrateListener(selected_index, refreshRates));
+    }
+
     private final Group CreateRefreshrateSelect() {
         Group refreshrate_group = new Group();
         Label label_rr = new Label("Refreshrate:", Skin.getSkin().getEditFont());
@@ -431,13 +449,13 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
     }
 
     private final Group CreateDisplayApply() {
-        Group apply = new Group();
+        Group apply_group = new Group();
         HorizButton apply_btn = new HorizButton("Apply", 120);
         apply_btn.addMouseClickListener(new DisplayApplyListener());
-        apply.addChild(apply_btn);
+        apply_group.addChild(apply_btn);
         apply_btn.place();
-        apply.compileCanvas();
-        return apply;
+        apply_group.compileCanvas();
+        return apply_group;
     }
     
     private final Group CreateDisplaySettings() {
@@ -665,6 +683,7 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
 		public final void rowChosen(Object o) {
 			mode = (DisplayModelItem)o;
 			DisplayModel.setCurrentResolution(mode);
+            fetchRefreshRates();
             //DisplayChangeForm display_change_form = new DisplayChangeForm(this);
 			//gui_root.addModalForm(display_change_form);
 		}

--- a/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
+++ b/tt/classes/com/oddlabs/tt/form/AbstractOptionsMenu.java
@@ -706,9 +706,15 @@ public abstract strictfp class AbstractOptionsMenu extends Form {
 		}
 	}
 
-    private final strictfp class DisplayApplyListener implements MouseClickListener {
+    private final strictfp class DisplayApplyListener implements MouseClickListener, DoNowListener {
+        public final void doChange(boolean switch_now) {
+            if(switch_now)
+                DisplayModel.saveToConfig();
+		}
+
 		public final void mouseClicked(int button, int x, int y, int clicks) {
-			DisplayModel.saveToConfig();
+			DisplayApplyForm display_change_form = new DisplayApplyForm(this);
+		    gui_root.addModalForm(display_change_form);
 		}
 	}
 

--- a/tt/classes/com/oddlabs/tt/form/DisplayApplyForm.java
+++ b/tt/classes/com/oddlabs/tt/form/DisplayApplyForm.java
@@ -1,0 +1,61 @@
+package com.oddlabs.tt.form;
+
+import com.oddlabs.tt.gui.CancelListener;
+import com.oddlabs.tt.gui.DoNowListener;
+import com.oddlabs.tt.gui.Form;
+import com.oddlabs.tt.gui.HorizButton;
+import com.oddlabs.tt.gui.LabelBox;
+import com.oddlabs.tt.gui.Skin;
+import com.oddlabs.tt.guievent.MouseClickListener;
+
+import com.oddlabs.tt.render.DisplayModel;
+import com.oddlabs.tt.render.DisplayModelItem;
+
+public final strictfp class DisplayApplyForm extends Form {
+    private final DoNowListener donow_listener;
+	private final HorizButton later_button;
+
+    public DisplayApplyForm(DoNowListener donow_listener) {
+		this.donow_listener = donow_listener;
+
+        //Build string
+        DisplayModelItem item = DisplayModel.getCurrentResolution();
+        String message = String.format("Changing resolution to:\nWidth: %d\nHeight: %d\nRefresh rate: %d\nFullscreen: %s\n\nRestart after applying and if you have issues, tell the maintainers.",
+                                        item.width(),
+                                        item.height(),
+                                        item.refreshRate(),
+                                        DisplayModel.inFullscreen() ? "Yes" : "No");
+
+		LabelBox info_label = new LabelBox(message, Skin.getSkin().getEditFont(), 500);
+		addChild(info_label);
+		HorizButton now_button = new HorizButton("Apply", 120);
+		addChild(now_button);
+		now_button.addMouseClickListener(new NowListener());
+		later_button = new HorizButton("Cancel", 120);
+		addChild(later_button);
+		later_button.addMouseClickListener(new CancelListener(this));
+		
+		// Place objects
+		info_label.place();
+		now_button.place(ORIGIN_BOTTOM_RIGHT);
+		later_button.place(now_button, LEFT_MID);
+
+		compileCanvas();
+		centerPos();
+	}
+
+    public final void setFocus() {
+		later_button.setFocus();
+	}
+
+    private final strictfp class NowListener implements MouseClickListener {
+		public final void mouseClicked(int button, int x, int y, int clicks) {
+			remove();
+			donow_listener.doChange(true);
+		}
+	}
+
+    protected final void doCancel() {
+		donow_listener.doChange(false);
+	}
+}

--- a/tt/classes/com/oddlabs/tt/form/DisplayBadDetected.java
+++ b/tt/classes/com/oddlabs/tt/form/DisplayBadDetected.java
@@ -1,0 +1,36 @@
+package com.oddlabs.tt.form;
+
+import com.oddlabs.tt.gui.CancelListener;
+import com.oddlabs.tt.gui.DoNowListener;
+import com.oddlabs.tt.gui.Form;
+import com.oddlabs.tt.gui.HorizButton;
+import com.oddlabs.tt.gui.LabelBox;
+import com.oddlabs.tt.gui.Skin;
+import com.oddlabs.tt.guievent.MouseClickListener;
+
+public final strictfp class DisplayBadDetected extends Form {
+    public DisplayBadDetected() {
+
+        //Build string
+        String message = String.format("Bad resolution or refresh rate was detected and automatically switched to the best available.");
+
+		LabelBox info_label = new LabelBox(message, Skin.getSkin().getEditFont(), 500);
+		addChild(info_label);
+		HorizButton now_button = new HorizButton("Ok", 120);
+		addChild(now_button);
+        now_button.addMouseClickListener(new NowListener());
+		
+		// Place objects
+		info_label.place();
+		now_button.place(ORIGIN_BOTTOM_RIGHT);
+
+		compileCanvas();
+		centerPos();
+	}
+
+    private final strictfp class NowListener implements MouseClickListener {
+		public final void mouseClicked(int button, int x, int y, int clicks) {
+			remove();
+		}
+	}
+}

--- a/tt/classes/com/oddlabs/tt/gui/LocalInput.java
+++ b/tt/classes/com/oddlabs/tt/gui/LocalInput.java
@@ -221,13 +221,4 @@ public final strictfp class LocalInput {
 		return Globals.VIEW_MIN/(getUnitsPerPixel()*Globals.ERROR_TOLERANCE);
 	}
 
-	public static void switchMode(GLFWVidMode mode) {
-		Settings.getSettings().new_view_width = mode.width();
-		Settings.getSettings().new_view_height = mode.height();
-		Settings.getSettings().new_view_freq = mode.refreshRate();
-		Settings.getSettings().view_width = mode.width();
-		Settings.getSettings().view_height = mode.height();
-		Settings.getSettings().view_freq = mode.refreshRate();
-		Settings.getSettings().save();
-	}
 }

--- a/tt/classes/com/oddlabs/tt/gui/PulldownMenu.java
+++ b/tt/classes/com/oddlabs/tt/gui/PulldownMenu.java
@@ -62,9 +62,8 @@ public final strictfp class PulldownMenu extends Group {// GUIObject {
 			item.setPos(0, item_pos_count);
 			item_pos_count += item_height;
 		}
-		//FIXME: This is a hack and has to be handled properly.
-		//int min_height = StrictMath.max(getHeight(), item_pos_count + Skin.getSkin().getPulldownData().getPulldownTop().getHeight());
-		int min_height = 25*items.size();
+
+		int min_height = item_pos_count + Skin.getSkin().getPulldownData().getPulldownTop().getHeight();
 		super.setDim(min_width, min_height);
 	}
 

--- a/tt/classes/com/oddlabs/tt/gui/PulldownMenu.java
+++ b/tt/classes/com/oddlabs/tt/gui/PulldownMenu.java
@@ -117,18 +117,6 @@ public final strictfp class PulldownMenu extends Group {// GUIObject {
 		}
 	}
 
-	public final void clearListeners() {
-		for (int i = 0; i<chosen_listeners.size(); i++) {
-			removeItemChosenListener((ItemChosenListener)chosen_listeners.get(i));
-		}
-	}
-
-	public final void listListeners() {
-		for (int i = 0; i<chosen_listeners.size(); i++) {
-			System.out.println((ItemChosenListener)chosen_listeners.get(i));
-		}
-	}
-
 	public final void addItemChosenListener(ItemChosenListener listener) {
 		chosen_listeners.add(listener);
 	}

--- a/tt/classes/com/oddlabs/tt/gui/PulldownMenu.java
+++ b/tt/classes/com/oddlabs/tt/gui/PulldownMenu.java
@@ -9,9 +9,9 @@ import com.oddlabs.tt.guievent.ItemChosenListener;
 import com.oddlabs.tt.guievent.MouseClickListener;
 
 public final strictfp class PulldownMenu extends Group {// GUIObject {
-	private final java.util.List chosen_listeners = new java.util.ArrayList();
+	private final List<ItemChosenListener> chosen_listeners = new ArrayList<ItemChosenListener>();
 
-	private final List items = new ArrayList();
+	private final List<PulldownItem> items = new ArrayList();
 	private int chosen_item_index = -1;
 	
 	public PulldownMenu() {
@@ -20,7 +20,7 @@ public final strictfp class PulldownMenu extends Group {// GUIObject {
 	}
 
 	public final PulldownItem getItem(int index) {
-		return (PulldownItem)items.get(index);
+		return items.get(index);
 	}
 
 	public final int getSize() {
@@ -62,12 +62,18 @@ public final strictfp class PulldownMenu extends Group {// GUIObject {
 			item.setPos(0, item_pos_count);
 			item_pos_count += item_height;
 		}
-		int min_height = StrictMath.max(height, item_pos_count + Skin.getSkin().getPulldownData().getPulldownTop().getHeight());
+		//FIXME: This is a hack and has to be handled properly.
+		//int min_height = StrictMath.max(getHeight(), item_pos_count + Skin.getSkin().getPulldownData().getPulldownTop().getHeight());
+		int min_height = 25*items.size();
 		super.setDim(min_width, min_height);
 	}
 
 	public final int getChosenItemIndex() {
 		return chosen_item_index;
+	}
+	public final void clearItems() {
+		clearChildren();
+		items.clear();
 	}
 
 	public final void chooseItem(int index) {
@@ -109,6 +115,18 @@ public final strictfp class PulldownMenu extends Group {// GUIObject {
 			ItemChosenListener listener = (ItemChosenListener)chosen_listeners.get(i);
 			if (listener != null)
 				listener.itemChosen(this, chosen_item_index);
+		}
+	}
+
+	public final void clearListeners() {
+		for (int i = 0; i<chosen_listeners.size(); i++) {
+			removeItemChosenListener((ItemChosenListener)chosen_listeners.get(i));
+		}
+	}
+
+	public final void listListeners() {
+		for (int i = 0; i<chosen_listeners.size(); i++) {
+			System.out.println((ItemChosenListener)chosen_listeners.get(i));
 		}
 	}
 

--- a/tt/classes/com/oddlabs/tt/render/Display.java
+++ b/tt/classes/com/oddlabs/tt/render/Display.java
@@ -35,6 +35,7 @@ public final strictfp class Display {
             System.out.println("Unable to initialize GLFW");
             return;
         }
+
         System.out.println("Is settings null? " + (Settings.getSettings() == null));
         width = Settings.getSettings().view_width;
         height = Settings.getSettings().view_height;
@@ -145,7 +146,8 @@ public final strictfp class Display {
     }
 
     public static GLFWVidMode[] getVidModes() {
-        org.lwjgl.glfw.GLFWVidMode.Buffer buffer = GLFW.glfwGetVideoModes(monitor);
+        long target_monitor = GLFW.glfwGetPrimaryMonitor();
+        org.lwjgl.glfw.GLFWVidMode.Buffer buffer = GLFW.glfwGetVideoModes(target_monitor);
         if (buffer == null) {
             return new GLFWVidMode[0];
         }

--- a/tt/classes/com/oddlabs/tt/render/DisplayModel.java
+++ b/tt/classes/com/oddlabs/tt/render/DisplayModel.java
@@ -134,7 +134,7 @@ public final class DisplayModel {
 
         // Check if refresh rate matches
         for(int i = 0; i<items.size(); i++) {
-            if (curr_resolution.refreshRate() == available_resolutions[i].refreshRate())
+            if (curr_resolution.refreshRate() == items.get(i).refreshRate())
                 return 1;
         }
         

--- a/tt/classes/com/oddlabs/tt/render/DisplayModel.java
+++ b/tt/classes/com/oddlabs/tt/render/DisplayModel.java
@@ -1,0 +1,181 @@
+package com.oddlabs.tt.render;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.lwjgl.glfw.GLFWVidMode;
+import org.lwjgl.glfw.GLFW;
+import com.oddlabs.tt.global.Settings;
+
+public final class DisplayModel {
+    private static GLFWVidMode[] available_resolutions = Display.getVidModes();;
+    private static DisplayModelItem curr_resolution;
+    private static Boolean fullscreen;
+
+    public static void init() {
+        fullscreen = Settings.getSettings().fullscreen;
+
+        curr_resolution = new DisplayModelItem();
+
+        int status = checkCurrentResolutionAvailability();
+
+        switch(status) {
+            // Refreshrate not available
+            case 0:
+                int refreshRate = getBestRefreshrate(curr_resolution);
+                curr_resolution.setRefreshRate(refreshRate);
+                break;
+            
+            // Resolution not available
+            case -1:
+                curr_resolution = getNativeMode();
+                break;
+            
+            // Return, no changes needed
+            default:
+                return;
+        }
+
+        // Apply to config
+        saveToConfig();
+    }
+
+    public static void saveToConfig() {
+        Settings.getSettings().fullscreen = (boolean)fullscreen;
+        curr_resolution.setToConfig();
+        Settings.getSettings().save();
+    }
+
+    public static void setFullscreen(Boolean bool) {
+        fullscreen = bool;
+    }
+
+    public static void setCurrentResolution(DisplayModelItem new_resolution) {
+        curr_resolution = new_resolution;
+    }
+
+    public static DisplayModelItem getCurrentResolution() {
+        return curr_resolution;
+    }
+
+    public static boolean inFullscreen() {
+        return fullscreen;
+    }
+
+    public static DisplayModelItem[] getUniqueResolutions() {
+       List<DisplayModelItem> items = getResolutionModes();
+       List<DisplayModelItem> new_items = new ArrayList<DisplayModelItem>();
+
+       for(int i = 0; i<items.size(); i++) {
+            DisplayModelItem new_item = items.get(i);
+            new_item.setRefreshRate(-1);
+            if(!new_items.contains(new_item)) {
+                new_items.add(new_item);
+            }
+       }
+
+       return new_items.toArray(new DisplayModelItem[new_items.size()]);
+    }
+
+    public static int[] getRefreshRates(DisplayModelItem resolution) {
+        List<DisplayModelItem> items = getResolutionModes(resolution);
+        int[] refreshRates = new int[items.size()];
+
+        if(refreshRates.length < 1) {
+            throw new RuntimeException("getRefreshRates found zero refreshrates on this resolution");
+        }
+
+        for(int i = 0; items.size() > i; i++) {
+            refreshRates[i] = items.get(i).refreshRate();
+        }
+
+        return refreshRates;
+    }
+
+    public static int[] getRefreshRates() {
+        return getRefreshRates(curr_resolution);
+    }
+
+    public static List<DisplayModelItem> getResolutionModes(DisplayModelItem resolution) {
+        List<DisplayModelItem> items = new ArrayList<DisplayModelItem>();
+
+        for(int i = 0; i<available_resolutions.length; i++) {
+            if (resolution.width() == available_resolutions[i].width() && resolution.height() == available_resolutions[i].height())
+                items.add(new DisplayModelItem(available_resolutions[i]));
+        }
+
+        return items;
+    }
+
+    public static List<DisplayModelItem> getResolutionModes() {
+        List<DisplayModelItem> items = new ArrayList<DisplayModelItem>();
+
+        for(int i = 0; i<available_resolutions.length; i++) {
+            items.add(new DisplayModelItem(available_resolutions[i]));
+        }
+
+        return items;
+    }
+
+    /*
+     * Checks if current resolution and refresh rate is available
+     * Returns:
+     * 1 All match
+     * 0 Refresh rate doesn't match
+     * -1 Width or height doesn't match
+     */
+    private static int checkCurrentResolutionAvailability() {
+        List<DisplayModelItem> items = getResolutionModes(curr_resolution);
+        
+        // If no resolutions found, return -1
+        if (items.size() < 1) {
+            return -1;
+        }
+
+        // Check if refresh rate matches
+        for(int i = 0; i<items.size(); i++) {
+            if (curr_resolution.refreshRate() == available_resolutions[i].refreshRate())
+                return 1;
+        }
+        
+        return 0;
+    }
+
+    private static int getBestRefreshrate(DisplayModelItem resolution) {
+        List<DisplayModelItem> items = getResolutionModes(resolution);
+
+        if (items.size() < 1) {
+            throw new RuntimeException("(selectBestRefreshrate) Couldn't get resolutions for current resolution:\nWidth: " + resolution.width() + "\nHeight: " + resolution.height());
+        }
+
+        int max_refreshRate = -1;
+
+        for (int i = 0; i<items.size(); i++) {
+            if(items.get(i).refreshRate() > max_refreshRate) {
+                max_refreshRate = items.get(i).refreshRate();
+            }
+        }
+
+        return max_refreshRate;
+    }
+
+    private static DisplayModelItem getNativeMode() {
+        int max_width = -1;
+        int max_height = -1;
+
+        for (int i = 0; i<available_resolutions.length; i++) {
+            if (available_resolutions[i].width() > max_width) {
+                max_width = available_resolutions[i].width();
+            }
+            if (available_resolutions[i].height() > max_height) {
+                max_height = available_resolutions[i].height();
+            }
+        }
+
+        DisplayModelItem new_mode = new DisplayModelItem(max_width, max_height, -1);
+        int max_refreshRate = getBestRefreshrate(new_mode);
+
+        new_mode.setRefreshRate(max_refreshRate);
+        return new_mode;
+    }
+}

--- a/tt/classes/com/oddlabs/tt/render/DisplayModel.java
+++ b/tt/classes/com/oddlabs/tt/render/DisplayModel.java
@@ -12,6 +12,9 @@ public final class DisplayModel {
     private static DisplayModelItem curr_resolution;
     private static Boolean fullscreen;
 
+    // Check to see if resolution was changed at boot
+    private static Boolean bad_mode = false;
+
     public static void init() {
         fullscreen = Settings.getSettings().fullscreen;
 
@@ -35,7 +38,8 @@ public final class DisplayModel {
             default:
                 return;
         }
-
+        // Set bad resolution variable
+        bad_mode = true;
         // Apply to config
         saveToConfig();
     }
@@ -115,6 +119,13 @@ public final class DisplayModel {
         }
 
         return items;
+    }
+
+    public static Boolean getBadModeStatus() {
+        return bad_mode;
+    }
+    public static void setBadModeStatus(Boolean _bad_mode) {
+        bad_mode = _bad_mode;
     }
 
     /*

--- a/tt/classes/com/oddlabs/tt/render/DisplayModelItem.java
+++ b/tt/classes/com/oddlabs/tt/render/DisplayModelItem.java
@@ -1,0 +1,89 @@
+package com.oddlabs.tt.render;
+
+import com.oddlabs.tt.global.Settings;
+import org.lwjgl.glfw.GLFWVidMode;
+
+
+public class DisplayModelItem {
+    private int width;
+    private int height;
+    private int refreshRate;
+
+    public DisplayModelItem(int _width, int _height, int _refreshRate) {
+        width = _width;
+        height = _height;
+        refreshRate = _refreshRate;
+    }
+
+    public DisplayModelItem(GLFWVidMode mode) {
+        width = mode.width();
+        height = mode.height();
+        refreshRate = mode.refreshRate();
+    }
+
+    public DisplayModelItem() {
+        loadFromConfig();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        if (obj.getClass() != this.getClass())
+            return false;
+        
+        DisplayModelItem item = (DisplayModelItem) obj;
+
+        if(item.width() == width && item.height() == height && item.refreshRate() == refreshRate)
+            return true;
+        return false;
+    }
+
+    public boolean resolution_equals(DisplayModelItem item) {
+        if (item == null)
+            return false;
+
+        if(item.width() == width && item.height() == height)
+            return true;
+        return false;
+    }
+
+    public int width() {
+        return width;
+    }
+
+    public int height() {
+        return height;
+    }
+
+    public int refreshRate() {
+        return refreshRate;
+    }
+
+    public void setWidth(int new_width) {
+        width = new_width;
+    }
+
+    public void setHeight(int new_height) {
+        height = new_height;
+    }
+
+    public void setRefreshRate(int new_refreshRate) {
+        refreshRate = new_refreshRate;
+    }
+
+    public void setToConfig() {
+        Settings.getSettings().new_view_width = width;
+		Settings.getSettings().new_view_height = height;
+		Settings.getSettings().new_view_freq = refreshRate;
+		Settings.getSettings().view_width = width;
+		Settings.getSettings().view_height = height;
+		Settings.getSettings().view_freq = refreshRate;
+    }
+
+    private void loadFromConfig() {
+        width = Settings.getSettings().view_width;
+        height = Settings.getSettings().view_height;
+        refreshRate = Settings.getSettings().view_freq;
+    }
+}

--- a/tt/classes/com/oddlabs/tt/render/Renderer.java
+++ b/tt/classes/com/oddlabs/tt/render/Renderer.java
@@ -133,6 +133,7 @@ import com.oddlabs.tt.util.StrictVector4f;
 import com.oddlabs.tt.util.Utils;
 import com.oddlabs.tt.vbo.VBO;
 import com.oddlabs.updater.UpdateInfo;
+import com.oddlabs.tt.render.DisplayModel;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -342,6 +343,7 @@ public final strictfp class Renderer {
         GUI gui = new GUI(languages);
 
         GlobalsInit.init();
+        DisplayModel.init();
         LocalInput.init();
 
         long startup_timei = System.currentTimeMillis() - start_time;


### PR DESCRIPTION
Works through testing, lots of changes and two new classes to keep track of resolution, DisplayModel and DisplayModelItem.
Changes to PulldownMenu height positions. Lots of changes to AbstractOptionsMenu for graphics tab GUI.

DisplayModel converts GLFWVidModes provided by Display to DisplayModelItems, checks for bad modes (both resolution and refresh rate), remembers fullscreen choice and has functions to find the best mode.

DisplayModelItem is GLFWVidMode with changes to allow saving to config and easier initialization through constructors.

Two new menus;
DisplayBadDetected that runs in main menu to check if DisplayModel changed the resolution from a bad one.
DisplayApplyForm to confirm a settings change.

Needs cleaning up and more documentation, but *should* work and probably better to have it than not.