### PR TITLE
Adds a steam deploy step to workflow

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -141,7 +141,7 @@ jobs:
         appId: ${{ vars.STEAM_APP_ID }}
         buildDescription: v1.2.3
         firstDepotIdOverride: 3945722
-        rootPath: build
+        rootPath: tt/build/dist/
         depot1Path: windows
         depot2Path: mac-arm64
         depot3Path: mac-x86

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -133,10 +133,6 @@ jobs:
       with:
         name: linux
         path: tt/build/dist/linux/
-    - name: Unzip Mac Build
-      run: |
-        unzip -o build/mac/.zip -d build/mac/
-        rm build/mac/.zip
     - name: Upload to steam
       uses: game-ci/steam-deploy@v3
       with:

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Ant
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-ant
 
-name: Java CI
+name: Build + Publish
 
 on:
   push:
@@ -104,3 +104,48 @@ jobs:
       with:
         name: mac-arm64
         path: tt/build/dist/macosx-arm64/
+
+# Steam upload job:
+#  - https://github.com/game-ci/steam-deploy#configuration
+#  - https://partner.steamgames.com/doc/sdk/uploading#1
+  deploy-to-steam:
+    if: github.ref == 'refs/heads/steam'
+    needs: [build-mac-arm64, build-mac-x86, build-windows, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Windows Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: windows
+        path: tt/build/dist/windows/
+    - name: Download Mac x86 Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: mac-x86
+        path: tt/build/dist/macosx-x86/
+    - name: Download Mac arm64 Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: mac-arm64
+        path: tt/build/dist/macosx-arm64/
+    - name: Download Linux Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: linux
+        path: tt/build/dist/linux/
+    - name: Unzip Mac Build
+      run: |
+        unzip -o build/mac/.zip -d build/mac/
+        rm build/mac/.zip
+    - name: Upload to steam
+      uses: game-ci/steam-deploy@v3
+      with:
+        username: ${{ vars.STEAM_USER }}
+        configVdf: ${{ secrets.STEAM_CONFIG_VDF }}
+        appId: ${{ vars.STEAM_APP_ID }}
+        buildDescription: v1.2.3
+        rootPath: build
+        depot1Path: windows
+        depot2Path: mac
+        depot3Path: linux
+        releaseBranch: prerelease

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -144,8 +144,10 @@ jobs:
         configVdf: ${{ secrets.STEAM_CONFIG_VDF }}
         appId: ${{ vars.STEAM_APP_ID }}
         buildDescription: v1.2.3
+        firstDepotIdOverride: 3945722
         rootPath: build
         depot1Path: windows
-        depot2Path: mac
-        depot3Path: linux
+        depot2Path: mac-arm64
+        depot3Path: mac-x86
+        depot4Path: linux
         releaseBranch: prerelease


### PR DESCRIPTION
Add a deploy to steam step for github workflow. Will only trigger off of a workflow for a branch labelled 'steam'. A user will need to fill out the github actions variables to use it. The pipeline has a comment of links to help you fill out each variable.

Currently what I am doing is running the steam workflow on my fork. This way I can keep my user's steam auth token separate from this repo until we have an auth token we are okay with anyone running an action on in this repository