### PR TITLE
Update Steam4j to latest for arm64 support

### DIFF
--- a/tt/classes/com/oddlabs/tt/Main.java
+++ b/tt/classes/com/oddlabs/tt/Main.java
@@ -6,6 +6,7 @@ import com.oddlabs.tt.global.Settings;
 import com.oddlabs.tt.gui.LocalInput;
 import com.oddlabs.tt.render.Display;
 import com.oddlabs.tt.render.Renderer;
+import com.oddlabs.tt.steam.SteamLibraryLoaderLwjgl3;
 import com.oddlabs.tt.util.Utils;
 import com.oddlabs.updater.UpdateInfo;
 
@@ -39,7 +40,7 @@ public final strictfp class Main {
     public static final void main(String[] args) {
         try {
             System.out.println("Loading Steam libraries...");
-            SteamAPI.loadLibraries();
+            SteamAPI.loadLibraries(new SteamLibraryLoaderLwjgl3());
             if (!SteamAPI.init()) {
                 // Steamworks initialization error, e.g. Steam client not running
                 System.out.println("Failed to initialize Steam API.");

--- a/tt/classes/com/oddlabs/tt/steam/SteamAchievementManager.java
+++ b/tt/classes/com/oddlabs/tt/steam/SteamAchievementManager.java
@@ -45,11 +45,6 @@ public class SteamAchievementManager implements SteamUserStatsCallback, SteamUse
         if (SteamAPI.isSteamRunning()) {
             steamUserStats = new SteamUserStats(this);
             steamUser = new SteamUser(this);
-            if (steamUserStats.requestCurrentStats()) {
-                debugPrint("Successfully requested current stats.");
-            } else {
-                debugPrint("Failed to request current stats.");
-            }
         } else {
             steamUser = null;
             steamUserStats = null;

--- a/tt/classes/com/oddlabs/tt/steam/SteamLibraryLoaderLwjgl3.java
+++ b/tt/classes/com/oddlabs/tt/steam/SteamLibraryLoaderLwjgl3.java
@@ -1,23 +1,24 @@
 package com.oddlabs.tt.steam;
 
 import com.codedisaster.steamworks.SteamLibraryLoader;
+
 import org.lwjgl.system.Library;
 import org.lwjgl.system.Platform;
 
 /**
- * LWJGL3-based Steam library loader implementation.
- * Based on steamworks4j-lwjgl3 loader from https://github.com/code-disaster/steamworks4j
+ * LWJGL3-based Steam library loader implementation. Based on steamworks4j-lwjgl3 loader from
+ * https://github.com/code-disaster/steamworks4j
  */
 public class SteamLibraryLoaderLwjgl3 implements SteamLibraryLoader {
-    
+
     private static final boolean DEBUG = false;
-    
+
     private void debug(String message) {
         if (DEBUG) {
             System.out.println("[SteamLoader] " + message);
         }
     }
-    
+
     @Override
     public void setLibraryPath(String libraryPath) {
         System.setProperty("org.lwjgl.librarypath", libraryPath);
@@ -36,7 +37,7 @@ public class SteamLibraryLoaderLwjgl3 implements SteamLibraryLoader {
         }
 
         debug("Final library name: " + libraryName);
-        
+
         // Let LWJGL3 do its magic
         try {
             Library.loadSystem("com.codedisaster.steamworks", libraryName);

--- a/tt/classes/com/oddlabs/tt/steam/SteamLibraryLoaderLwjgl3.java
+++ b/tt/classes/com/oddlabs/tt/steam/SteamLibraryLoaderLwjgl3.java
@@ -1,0 +1,52 @@
+package com.oddlabs.tt.steam;
+
+import com.codedisaster.steamworks.SteamLibraryLoader;
+import org.lwjgl.system.Library;
+import org.lwjgl.system.Platform;
+
+/**
+ * LWJGL3-based Steam library loader implementation.
+ * Based on steamworks4j-lwjgl3 loader from https://github.com/code-disaster/steamworks4j
+ */
+public class SteamLibraryLoaderLwjgl3 implements SteamLibraryLoader {
+    
+    private static final boolean DEBUG = false;
+    
+    private void debug(String message) {
+        if (DEBUG) {
+            System.out.println("[SteamLoader] " + message);
+        }
+    }
+    
+    @Override
+    public void setLibraryPath(String libraryPath) {
+        System.setProperty("org.lwjgl.librarypath", libraryPath);
+    }
+
+    @Override
+    public boolean loadLibrary(String libraryName) {
+        debug("Attempting to load library: " + libraryName);
+        Platform os = Platform.get();
+        Platform.Architecture arch = Platform.getArchitecture();
+        debug("Platform: " + os + ", Architecture: " + arch);
+
+        // On Windows 64-bit, Steam libraries are suffixed with "64".
+        if (os == Platform.WINDOWS && arch == Platform.Architecture.X64) {
+            libraryName = libraryName + "64";
+        }
+
+        debug("Final library name: " + libraryName);
+        
+        // Let LWJGL3 do its magic
+        try {
+            Library.loadSystem("com.codedisaster.steamworks", libraryName);
+            debug("Successfully loaded: " + libraryName);
+        } catch (Throwable t) {
+            System.err.println("Failed to load library: " + libraryName);
+            t.printStackTrace();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tt/ivy.xml
+++ b/tt/ivy.xml
@@ -1,6 +1,6 @@
 <ivy-module version="2.0">
   <info organisation="tribaltrouble" module="tribaltrouble"/>
   <dependencies>
-    <dependency org="com.code-disaster.steamworks4j" name="steamworks4j" rev="1.9.0"/>
+    <dependency org="com.code-disaster.steamworks4j" name="steamworks4j" rev="1.10.0"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
Update Steam4j to latest for arm64 support and supports the steam sdk version 1.62