### PR TITLE
Track peons gathering each resource type

### DIFF
--- a/tt/classes/com/oddlabs/tt/gui/DeploySpinner.java
+++ b/tt/classes/com/oddlabs/tt/gui/DeploySpinner.java
@@ -1,18 +1,27 @@
 package com.oddlabs.tt.gui;
 
+import com.oddlabs.tt.landscape.TreeSupply;
 import com.oddlabs.tt.model.Building;
 import com.oddlabs.tt.model.DeployContainer;
+import com.oddlabs.tt.model.HarvesterTracker;
+import com.oddlabs.tt.model.IronSupply;
+import com.oddlabs.tt.model.RockSupply;
+import com.oddlabs.tt.model.RubberSupply;
+import com.oddlabs.tt.model.Unit;
 import com.oddlabs.tt.player.PlayerInterface;
 import com.oddlabs.tt.viewer.WorldViewer;
 import com.oddlabs.util.Quad;
 
 public final strictfp class DeploySpinner extends IconSpinner {
     private final PlayerInterface player_interface;
+    private final WorldViewer viewer;
     private Class supply_type;
     private int deploy_type;
     private Building current_building;
     private int num_orders = 0;
     private int order_size = 0;
+    // Track how many harvesters we've requested to recall
+    private int recall_count = 0;
 
     public DeploySpinner(
             WorldViewer viewer,
@@ -23,22 +32,68 @@ public final strictfp class DeploySpinner extends IconSpinner {
             String shortcut_key) {
         super(viewer, icon_quad, tool_tip, tool_tip_icons, shortcut_key);
         this.player_interface = player_interface;
+        this.viewer = viewer;
     }
 
     public void setContainers(Building current_building, int deploy_type, Class supply_type) {
         this.current_building = current_building;
         this.deploy_type = deploy_type;
         this.supply_type = supply_type;
+        this.recall_count = 0;
         if (!current_building.isDead())
             num_orders = current_building.getDeployContainer(deploy_type).getNumOrders();
+    }
+
+    /**
+     * Get the supply type for harvesting based on deploy type. Returns null if this is not a
+     * harvest deploy type.
+     */
+    private Class getHarvestSupplyType() {
+        switch (deploy_type) {
+            case Building.KEY_DEPLOY_PEON_HARVEST_TREE:
+                return TreeSupply.class;
+            case Building.KEY_DEPLOY_PEON_HARVEST_ROCK:
+                return RockSupply.class;
+            case Building.KEY_DEPLOY_PEON_HARVEST_IRON:
+                return IronSupply.class;
+            case Building.KEY_DEPLOY_PEON_HARVEST_RUBBER:
+                return RubberSupply.class;
+            default:
+                return null;
+        }
+    }
+
+    /** Check if this is a harvest type deployment. */
+    private boolean isHarvestType() {
+        return getHarvestSupplyType() != null;
+    }
+
+    /** Get the count of active harvesters for this resource type. */
+    private int getActiveHarvesterCount() {
+        Class harvestType = getHarvestSupplyType();
+        if (harvestType != null && current_building != null && !current_building.isDead()) {
+            HarvesterTracker tracker = current_building.getOwner().getHarvesterTracker();
+            return tracker.getHarvesterCount(harvestType);
+        }
+        return 0;
     }
 
     public final int computeCount() {
         if (current_building != null && !current_building.isDead()) {
             DeployContainer deploy_container = current_building.getDeployContainer(deploy_type);
-            return StrictMath.min(
-                    deploy_container.getMaxSupplyCount(),
-                    StrictMath.max(0, deploy_container.getNumSupplies() + getOrderDiff()));
+            int deployingCount =
+                    StrictMath.min(
+                            deploy_container.getMaxSupplyCount(),
+                            StrictMath.max(0, deploy_container.getNumSupplies() + getOrderDiff()));
+
+            // For harvest types, add the count of active harvesters
+            if (isHarvestType()) {
+                int activeCount = getActiveHarvesterCount();
+                // Subtract recall_count to show anticipated count after recalls
+                return StrictMath.max(0, activeCount + deployingCount - recall_count);
+            }
+
+            return deployingCount;
         } else return 0;
     }
 
@@ -82,6 +137,31 @@ public final strictfp class DeploySpinner extends IconSpinner {
 
     protected final void decrease(int amount) {
         if (!current_building.isDead() && computeCount() > 0) {
+            // For harvest types, we recall active harvesters
+            if (isHarvestType()) {
+                int activeCount = getActiveHarvesterCount();
+                int deployingCount =
+                        current_building.getDeployContainer(deploy_type).getNumSupplies()
+                                + getOrderDiff();
+
+                // First cancel any pending deployments
+                int cancelAmount = StrictMath.min(amount, StrictMath.max(0, deployingCount));
+                if (cancelAmount > 0) {
+                    order_size -= cancelAmount;
+                    num_orders -= cancelAmount;
+                    amount -= cancelAmount;
+                }
+
+                // Then queue recalls for active harvesters
+                if (amount > 0) {
+                    int recallAmount =
+                            StrictMath.min(amount, StrictMath.max(0, activeCount - recall_count));
+                    recall_count += recallAmount;
+                }
+                return;
+            }
+
+            // Original behavior for non-harvest types
             int num_units = current_building.getDeployContainer(deploy_type).getNumSupplies();
 
             if (num_units > -getOrderDiff() /* && num_supplies > -getOrderDiff()*/) {
@@ -100,8 +180,33 @@ public final strictfp class DeploySpinner extends IconSpinner {
     }
 
     protected final void release() {
+        // For harvest types, execute recalls
+        if (isHarvestType() && recall_count > 0) {
+            executeRecalls();
+        }
         order(order_size);
         order_size = 0;
+        recall_count = 0;
+    }
+
+    /** Execute the queued harvester recalls. Recalls the harvesters nearest to the armory. */
+    private void executeRecalls() {
+        Class harvestType = getHarvestSupplyType();
+        if (harvestType == null || current_building == null || current_building.isDead()) {
+            return;
+        }
+
+        HarvesterTracker tracker = current_building.getOwner().getHarvesterTracker();
+        float buildingX = current_building.getPositionX();
+        float buildingY = current_building.getPositionY();
+
+        for (int i = 0; i < recall_count; i++) {
+            Unit nearest = tracker.findNearestHarvester(harvestType, buildingX, buildingY);
+            if (nearest != null && !nearest.isDead()) {
+                // Send the peon back to the building
+                player_interface.recallHarvester(nearest, current_building);
+            }
+        }
     }
 
     protected final int getOrderSize() {

--- a/tt/classes/com/oddlabs/tt/model/HarvesterTracker.java
+++ b/tt/classes/com/oddlabs/tt/model/HarvesterTracker.java
@@ -1,0 +1,134 @@
+package com.oddlabs.tt.model;
+
+import com.oddlabs.tt.landscape.TreeSupply;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tracks the number of peons currently assigned to gathering each resource type. This allows the UI
+ * to display the count of active harvesters per resource.
+ */
+public final strictfp class HarvesterTracker {
+    // Maps resource type (Class) to set of units gathering that resource
+    private final Map harvestersByType = new HashMap();
+
+    public HarvesterTracker() {
+        // Initialize sets for each resource type
+        harvestersByType.put(TreeSupply.class, new HashSet());
+        harvestersByType.put(RockSupply.class, new HashSet());
+        harvestersByType.put(IronSupply.class, new HashSet());
+        harvestersByType.put(RubberSupply.class, new HashSet());
+    }
+
+    /**
+     * Register a unit as actively gathering a specific resource type.
+     *
+     * @param unit The unit to register
+     * @param supplyType The resource type being gathered
+     */
+    public void registerHarvester(Unit unit, Class supplyType) {
+        // First remove from any other type it might be registered with
+        unregisterHarvester(unit);
+
+        Set harvesters = (Set) harvestersByType.get(supplyType);
+        if (harvesters != null) {
+            harvesters.add(unit);
+        }
+    }
+
+    /**
+     * Unregister a unit from all resource types. Called when the unit dies, is interrupted, or
+     * stops gathering.
+     *
+     * @param unit The unit to unregister
+     */
+    public void unregisterHarvester(Unit unit) {
+        Iterator it = harvestersByType.values().iterator();
+        while (it.hasNext()) {
+            Set harvesters = (Set) it.next();
+            harvesters.remove(unit);
+        }
+    }
+
+    /**
+     * Get the count of harvesters for a specific resource type.
+     *
+     * @param supplyType The resource type
+     * @return The number of active harvesters
+     */
+    public int getHarvesterCount(Class supplyType) {
+        Set harvesters = (Set) harvestersByType.get(supplyType);
+        if (harvesters != null) {
+            // Clean up dead units from the set
+            cleanupDeadUnits(harvesters);
+            return harvesters.size();
+        }
+        return 0;
+    }
+
+    /**
+     * Get all harvesters of a specific resource type.
+     *
+     * @param supplyType The resource type
+     * @return Set of units gathering that resource
+     */
+    public Set getHarvesters(Class supplyType) {
+        Set harvesters = (Set) harvestersByType.get(supplyType);
+        if (harvesters != null) {
+            cleanupDeadUnits(harvesters);
+            return harvesters;
+        }
+        return new HashSet();
+    }
+
+    /**
+     * Find the harvester nearest to a given position.
+     *
+     * @param supplyType The resource type
+     * @param targetX Target X position
+     * @param targetY Target Y position
+     * @return The nearest unit, or null if none found
+     */
+    public Unit findNearestHarvester(Class supplyType, float targetX, float targetY) {
+        Set harvesters = (Set) harvestersByType.get(supplyType);
+        if (harvesters == null || harvesters.isEmpty()) {
+            return null;
+        }
+
+        cleanupDeadUnits(harvesters);
+
+        Unit nearest = null;
+        float nearestDistSq = Float.MAX_VALUE;
+
+        Iterator it = harvesters.iterator();
+        while (it.hasNext()) {
+            Unit unit = (Unit) it.next();
+            if (!unit.isDead()) {
+                float dx = unit.getPositionX() - targetX;
+                float dy = unit.getPositionY() - targetY;
+                float distSq = dx * dx + dy * dy;
+                if (distSq < nearestDistSq) {
+                    nearestDistSq = distSq;
+                    nearest = unit;
+                }
+            }
+        }
+
+        return nearest;
+    }
+
+    /** Remove dead units from a set. */
+    private void cleanupDeadUnits(Set harvesters) {
+        Iterator it = harvesters.iterator();
+        while (it.hasNext()) {
+            Unit unit = (Unit) it.next();
+            if (unit.isDead()) {
+                it.remove();
+            }
+        }
+    }
+}

--- a/tt/classes/com/oddlabs/tt/model/Selectable.java
+++ b/tt/classes/com/oddlabs/tt/model/Selectable.java
@@ -204,8 +204,17 @@ public abstract class Selectable extends Model implements Target, Animated, Mode
     public final void initTarget(Target target, int action, boolean aggressive) {
         assert !isDead();
         if (target == null) return;
+        onClearingControllers();
         clearControllerStack();
         setTarget(target, action, aggressive);
+    }
+
+    /**
+     * Called before controller stack is cleared during initTarget. Subclasses can override to
+     * perform cleanup.
+     */
+    protected void onClearingControllers() {
+        // Default implementation does nothing
     }
 
     protected abstract void setTarget(Target target, int action, boolean aggressive);

--- a/tt/classes/com/oddlabs/tt/model/Unit.java
+++ b/tt/classes/com/oddlabs/tt/model/Unit.java
@@ -350,6 +350,8 @@ public strictfp class Unit extends Selectable implements Occupant, Movable {
         if (getAbilities().hasAbilities(Abilities.MAGIC)) {
             getOwner().setActiveChieftain(null);
         }
+        // Unregister from harvester tracker if this unit was gathering
+        getOwner().getHarvesterTracker().unregisterHarvester(this);
         free();
         if (!getAbilities().hasAbilities(Abilities.MAGIC)) {
             int result = getOwner().getUnitCountContainer().increaseSupply(-1);
@@ -534,6 +536,11 @@ public strictfp class Unit extends Selectable implements Occupant, Movable {
     public final float getDefenseChance() {
         if (getCurrentController() instanceof StunController) return 0;
         else return super.getDefenseChance();
+    }
+
+    protected void onClearingControllers() {
+        // Unregister from harvester tracker when receiving new orders
+        getOwner().getHarvesterTracker().unregisterHarvester(this);
     }
 
     private final void walkToTarget(Target target, boolean scan_attack) {

--- a/tt/classes/com/oddlabs/tt/model/behaviour/GatherController.java
+++ b/tt/classes/com/oddlabs/tt/model/behaviour/GatherController.java
@@ -22,6 +22,12 @@ public final strictfp class GatherController extends Controller {
         this.unit = unit;
         this.supply = supply;
         this.supply_type = supply_type;
+        // Register this unit as a harvester for this supply type
+        unit.getOwner().getHarvesterTracker().registerHarvester(unit, supply_type);
+    }
+
+    public final Unit getUnit() {
+        return unit;
     }
 
     public final Class getSupplyType() {
@@ -50,6 +56,8 @@ public final strictfp class GatherController extends Controller {
                 unit.setBehaviour(new WalkBehaviour(unit, supply_tracker, false));
             }
         } else {
+            // Unregister before stopping gathering
+            unit.getOwner().getHarvesterTracker().unregisterHarvester(unit);
             unit.swapController(new TransferUnitController(unit));
         }
     }
@@ -66,6 +74,8 @@ public final strictfp class GatherController extends Controller {
                             .increaseSupply(unit.getSupplyContainer().getNumSupplies());
             unit.getSupplyContainer().increaseSupply(-num_supplies, unit_supply_type);
             if (unit.getSupplyContainer().getNumSupplies() > 0) {
+                // Resource container is full, unit enters building - stop gathering
+                unit.getOwner().getHarvesterTracker().unregisterHarvester(unit);
                 unit.popController();
                 unit.pushController(new EnterController(unit, building));
             } else gather();
@@ -76,6 +86,8 @@ public final strictfp class GatherController extends Controller {
                             new BuildingFinder(unit.getOwner(), Abilities.SUPPLY_CONTAINER));
             unit.setBehaviour(new WalkBehaviour(unit, building_tracker, false));
         } else {
+            // Can't find dropoff location, stop gathering
+            unit.getOwner().getHarvesterTracker().unregisterHarvester(unit);
             unit.popController();
         }
     }

--- a/tt/classes/com/oddlabs/tt/player/Player.java
+++ b/tt/classes/com/oddlabs/tt/player/Player.java
@@ -8,6 +8,7 @@ import com.oddlabs.tt.landscape.World;
 import com.oddlabs.tt.model.Abilities;
 import com.oddlabs.tt.model.Army;
 import com.oddlabs.tt.model.Building;
+import com.oddlabs.tt.model.HarvesterTracker;
 import com.oddlabs.tt.model.IronSupply;
 import com.oddlabs.tt.model.Race;
 import com.oddlabs.tt.model.RacesResources;
@@ -51,6 +52,7 @@ public final strictfp class Player implements PlayerInterface {
     private final Army units = new Army();
     private final SupplyContainer unit_count;
     private final SupplyContainer building_count = new SupplyContainer(MAX_BUILDING_COUNT);
+    private final HarvesterTracker harvester_tracker = new HarvesterTracker();
 
     private final float[] color;
 
@@ -361,6 +363,10 @@ public final strictfp class Player implements PlayerInterface {
         return building_count;
     }
 
+    public final HarvesterTracker getHarvesterTracker() {
+        return harvester_tracker;
+    }
+
     public final void setActiveChieftain(Unit chieftain) {
         this.chieftain = chieftain;
     }
@@ -493,6 +499,13 @@ public final strictfp class Player implements PlayerInterface {
                         .findGridTargets(grid_x, grid_y, selection.length, selection.length != 1);
         for (int i = 0; i < selection.length; i++) {
             if (isValid(selection[i])) selection[i].initTarget(targets[i], action, aggressive);
+        }
+    }
+
+    public final void recallHarvester(Unit harvester, Building building) {
+        if (isValid(harvester) && isValid(building)) {
+            // Send the harvester to enter the building
+            harvester.initTarget(building, Target.ACTION_MOVE, false);
         }
     }
 

--- a/tt/classes/com/oddlabs/tt/player/PlayerInterface.java
+++ b/tt/classes/com/oddlabs/tt/player/PlayerInterface.java
@@ -42,4 +42,6 @@ public strictfp interface PlayerInterface {
     void setPreferredGamespeed(int speed);
 
     void changePreferredGamespeed(int delta);
+
+    void recallHarvester(Unit harvester, Building building);
 }


### PR DESCRIPTION
Implement active harvester count tracking for each resource type:
- Create HarvesterTracker class to track peons gathering resources
- Register peons when GatherController starts gathering
- Unregister on death, task interruption, or max resource reached
- Display active harvester count in DeploySpinner UI
- Add recall functionality when minus is pressed (recalls nearest peon)
- Support both plus (deploy) and minus (cancel/recall) operations

The displayed number represents currently active harvesters plus those being deployed, matching Tribal Trouble 2 behavior.