### PR TITLE
Add notifications to discord channel for github activity

### DIFF
--- a/.github/workflows/notify-issues-prs.yml
+++ b/.github/workflows/notify-issues-prs.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, closed]
   pull_request:
     types: [opened, closed, ready_for_review]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   notify:
@@ -50,19 +48,14 @@ jobs:
              ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
 
     - name: Notify Discord on PR Opened
-      if: github.event_name == 'pull_request' && github.event.action == 'opened'
+      if: github.event_name == 'pull_request' && github.event.action == 'opened' && github.event.pull_request.draft == false
       run: |
         PR_TITLE="${{ github.event.pull_request.title }}"
         PR_URL="${{ github.event.pull_request.html_url }}"
         PR_NUMBER="${{ github.event.pull_request.number }}"
         AUTHOR="${{ github.event.pull_request.user.login }}"
-        IS_DRAFT="${{ github.event.pull_request.draft }}"
 
-        if [ "$IS_DRAFT" = "true" ]; then
-          MESSAGE="📝 **Draft PR Opened: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Author:** $AUTHOR\n**URL:** $PR_URL"
-        else
-          MESSAGE="🔀 **New Pull Request Opened: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Author:** $AUTHOR\n**URL:** $PR_URL"
-        fi
+        MESSAGE="🔀 **New Pull Request Opened: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Author:** $AUTHOR\n**URL:** $PR_URL"
 
         curl -H "Content-Type: application/json" \
              -d "{\"content\": \"$MESSAGE\"}" \
@@ -93,32 +86,6 @@ jobs:
         BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
 
         MESSAGE="✅ **PR Merged: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Author:** $AUTHOR\n**Merged by:** $MERGED_BY\n**Into:** $BASE_BRANCH\n**URL:** $PR_URL"
-
-        curl -H "Content-Type: application/json" \
-             -d "{\"content\": \"$MESSAGE\"}" \
-             ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
-
-    - name: Notify Discord on PR Review
-      if: github.event_name == 'pull_request_review'
-      run: |
-        PR_TITLE="${{ github.event.pull_request.title }}"
-        PR_URL="${{ github.event.pull_request.html_url }}"
-        PR_NUMBER="${{ github.event.pull_request.number }}"
-        REVIEWER="${{ github.event.review.user.login }}"
-        REVIEW_STATE="${{ github.event.review.state }}"
-
-        if [ "$REVIEW_STATE" = "approved" ]; then
-          EMOJI="✅"
-          STATUS="Approved"
-        elif [ "$REVIEW_STATE" = "changes_requested" ]; then
-          EMOJI="🔴"
-          STATUS="Changes Requested"
-        else
-          # Skip comment-only reviews (just regular comments, not approve/request changes)
-          exit 0
-        fi
-
-        MESSAGE="$EMOJI **PR Review: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Reviewer:** $REVIEWER\n**Status:** $STATUS\n**URL:** $PR_URL"
 
         curl -H "Content-Type: application/json" \
              -d "{\"content\": \"$MESSAGE\"}" \

--- a/.github/workflows/notify-issues-prs.yml
+++ b/.github/workflows/notify-issues-prs.yml
@@ -1,0 +1,99 @@
+name: Notify on Issues and PRs
+
+on:
+  issues:
+    types: [opened, closed]
+  pull_request:
+    types: [opened, closed, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify Discord on Issue Opened
+      if: github.event_name == 'issues' && github.event.action == 'opened'
+      run: |
+        ISSUE_TITLE="${{ github.event.issue.title }}"
+        ISSUE_URL="${{ github.event.issue.html_url }}"
+        ISSUE_NUMBER="${{ github.event.issue.number }}"
+        AUTHOR="${{ github.event.issue.user.login }}"
+
+        MESSAGE="🐛 **New Issue Opened: #$ISSUE_NUMBER**\n\n**Title:** $ISSUE_TITLE\n**Author:** $AUTHOR\n**URL:** $ISSUE_URL"
+
+        curl -H "Content-Type: application/json" \
+             -d "{\"content\": \"$MESSAGE\"}" \
+             ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+
+    - name: Notify Discord on Issue Closed
+      if: github.event_name == 'issues' && github.event.action == 'closed'
+      run: |
+        ISSUE_TITLE="${{ github.event.issue.title }}"
+        ISSUE_URL="${{ github.event.issue.html_url }}"
+        ISSUE_NUMBER="${{ github.event.issue.number }}"
+        CLOSED_BY="${{ github.event.sender.login }}"
+        STATE_REASON="${{ github.event.issue.state_reason }}"
+
+        if [ "$STATE_REASON" = "completed" ]; then
+          STATUS="✅ Completed"
+        elif [ "$STATE_REASON" = "not_planned" ]; then
+          STATUS="❌ Closed as not planned"
+        else
+          STATUS="Closed"
+        fi
+
+        MESSAGE="🔒 **Issue Closed: #$ISSUE_NUMBER**\n\n**Title:** $ISSUE_TITLE\n**Status:** $STATUS\n**Closed by:** $CLOSED_BY\n**URL:** $ISSUE_URL"
+
+        curl -H "Content-Type: application/json" \
+             -d "{\"content\": \"$MESSAGE\"}" \
+             ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+
+    - name: Notify Discord on PR Opened
+      if: github.event_name == 'pull_request' && github.event.action == 'opened'
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        PR_URL="${{ github.event.pull_request.html_url }}"
+        PR_NUMBER="${{ github.event.pull_request.number }}"
+        AUTHOR="${{ github.event.pull_request.user.login }}"
+        IS_DRAFT="${{ github.event.pull_request.draft }}"
+
+        if [ "$IS_DRAFT" = "true" ]; then
+          MESSAGE="📝 **Draft PR Opened: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Author:** $AUTHOR\n**URL:** $PR_URL"
+        else
+          MESSAGE="🔀 **New Pull Request Opened: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Author:** $AUTHOR\n**URL:** $PR_URL"
+        fi
+
+        curl -H "Content-Type: application/json" \
+             -d "{\"content\": \"$MESSAGE\"}" \
+             ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+
+    - name: Notify Discord on PR Ready for Review
+      if: github.event_name == 'pull_request' && github.event.action == 'ready_for_review'
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        PR_URL="${{ github.event.pull_request.html_url }}"
+        PR_NUMBER="${{ github.event.pull_request.number }}"
+        AUTHOR="${{ github.event.pull_request.user.login }}"
+
+        MESSAGE="👀 **PR Ready for Review: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Author:** $AUTHOR\n**URL:** $PR_URL"
+
+        curl -H "Content-Type: application/json" \
+             -d "{\"content\": \"$MESSAGE\"}" \
+             ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+
+    - name: Notify Discord on PR Merged
+      if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        PR_URL="${{ github.event.pull_request.html_url }}"
+        PR_NUMBER="${{ github.event.pull_request.number }}"
+        AUTHOR="${{ github.event.pull_request.user.login }}"
+        MERGED_BY="${{ github.event.pull_request.merged_by.login }}"
+        BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+
+        MESSAGE="✅ **PR Merged: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Author:** $AUTHOR\n**Merged by:** $MERGED_BY\n**Into:** $BASE_BRANCH\n**URL:** $PR_URL"
+
+        curl -H "Content-Type: application/json" \
+             -d "{\"content\": \"$MESSAGE\"}" \
+             ${{ secrets.DISCORD_WEBHOOK_GITHUB }}

--- a/.github/workflows/notify-issues-prs.yml
+++ b/.github/workflows/notify-issues-prs.yml
@@ -97,3 +97,29 @@ jobs:
         curl -H "Content-Type: application/json" \
              -d "{\"content\": \"$MESSAGE\"}" \
              ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+
+    - name: Notify Discord on PR Review
+      if: github.event_name == 'pull_request_review'
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        PR_URL="${{ github.event.pull_request.html_url }}"
+        PR_NUMBER="${{ github.event.pull_request.number }}"
+        REVIEWER="${{ github.event.review.user.login }}"
+        REVIEW_STATE="${{ github.event.review.state }}"
+
+        if [ "$REVIEW_STATE" = "approved" ]; then
+          EMOJI="✅"
+          STATUS="Approved"
+        elif [ "$REVIEW_STATE" = "changes_requested" ]; then
+          EMOJI="🔴"
+          STATUS="Changes Requested"
+        else
+          # Skip comment-only reviews (just regular comments, not approve/request changes)
+          exit 0
+        fi
+
+        MESSAGE="$EMOJI **PR Review: #$PR_NUMBER**\n\n**Title:** $PR_TITLE\n**Reviewer:** $REVIEWER\n**Status:** $STATUS\n**URL:** $PR_URL"
+
+        curl -H "Content-Type: application/json" \
+             -d "{\"content\": \"$MESSAGE\"}" \
+             ${{ secrets.DISCORD_WEBHOOK_GITHUB }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that sends Discord notifications for the following activity:
Issues:

Issue Opened — when a new issue is created
Issue Closed — when an issue is closed (shows whether completed or not planned)

Pull Requests:

PR Opened — when a non-draft PR is created
PR Ready for Review — when a draft PR is marked ready for review
PR Merged — when a PR is merged (shows who merged it and into which branch)