### PR TITLE
Add spectating of running games

### DIFF
--- a/common/classes/com/oddlabs/matchmaking/MatchmakingClientInterface.java
+++ b/common/classes/com/oddlabs/matchmaking/MatchmakingClientInterface.java
@@ -63,6 +63,8 @@ public strictfp interface MatchmakingClientInterface {
 
     public void receiveRoutedEvent(HostSequenceID from, ARMIEvent event);
 
+    public void receiveSpectatorData(byte[] world_params_data, byte[] event_log_data, int current_tick);
+
     public void loginOK(String username, TunnelAddress address);
 
     public void loginError(int error_code);

--- a/common/classes/com/oddlabs/matchmaking/MatchmakingClientInterface.java
+++ b/common/classes/com/oddlabs/matchmaking/MatchmakingClientInterface.java
@@ -64,10 +64,11 @@ public strictfp interface MatchmakingClientInterface {
 
     public void receiveRoutedEvent(HostSequenceID from, ARMIEvent event);
 
-    public void receiveSpectatorData(
-            byte[] world_params_data, byte[] event_log_data, int current_tick);
+    public void receiveSpectatorData(byte[] world_params_data);
 
     public void loginOK(String username, TunnelAddress address);
 
     public void loginError(int error_code);
+
+    public void receiveSpectatorEventLog(byte[] event_log_data, int current_tick);
 }

--- a/common/classes/com/oddlabs/matchmaking/MatchmakingClientInterface.java
+++ b/common/classes/com/oddlabs/matchmaking/MatchmakingClientInterface.java
@@ -22,6 +22,7 @@ public strictfp interface MatchmakingClientInterface {
     public static final int CHAT_ERROR_TOO_MANY_USERS = 10;
     public static final int CHAT_ERROR_INVALID_NAME = 11;
     public static final int CHAT_ERROR_NO_SUCH_NICK = 12;
+    public static final int CHAT_ERROR_SPECTATE_FAILED = 13;
 
     public void updateProfileList(Profile[] profiles, String last_profile_nick);
 

--- a/common/classes/com/oddlabs/matchmaking/MatchmakingClientInterface.java
+++ b/common/classes/com/oddlabs/matchmaking/MatchmakingClientInterface.java
@@ -64,7 +64,8 @@ public strictfp interface MatchmakingClientInterface {
 
     public void receiveRoutedEvent(HostSequenceID from, ARMIEvent event);
 
-    public void receiveSpectatorData(byte[] world_params_data, byte[] event_log_data, int current_tick);
+    public void receiveSpectatorData(
+            byte[] world_params_data, byte[] event_log_data, int current_tick);
 
     public void loginOK(String username, TunnelAddress address);
 

--- a/common/classes/com/oddlabs/matchmaking/MatchmakingServerInterface.java
+++ b/common/classes/com/oddlabs/matchmaking/MatchmakingServerInterface.java
@@ -43,6 +43,8 @@ public strictfp interface MatchmakingServerInterface {
 
     public void requestInfo(String nick);
 
+    public void requestSpectate(String nick);
+
     public void requestList(int type, int update_key);
 
     public void acceptTunnel(HostSequenceID host_seq);
@@ -66,6 +68,8 @@ public strictfp interface MatchmakingServerInterface {
     public void gameLostNotify();
 
     public void gameWonNotify();
+
+    public void updateCommandEvent(int tick, int client_id, short event_size, byte[] event_data);
 
     public void updateGameStatus(int tick, int[] status);
 

--- a/common/classes/com/oddlabs/matchmaking/MatchmakingServerInterface.java
+++ b/common/classes/com/oddlabs/matchmaking/MatchmakingServerInterface.java
@@ -76,4 +76,6 @@ public strictfp interface MatchmakingServerInterface {
     public void updateWorldParams(byte[] world_params_data);
 
     public void updateSpectatorInfo(int tick, String info);
+
+    public void requestSpectatorEventLog();
 }

--- a/common/classes/com/oddlabs/matchmaking/MatchmakingServerInterface.java
+++ b/common/classes/com/oddlabs/matchmaking/MatchmakingServerInterface.java
@@ -73,5 +73,7 @@ public strictfp interface MatchmakingServerInterface {
 
     public void updateGameStatus(int tick, int[] status);
 
+    public void updateWorldParams(byte[] world_params_data);
+
     public void updateSpectatorInfo(int tick, String info);
 }

--- a/common/classes/com/oddlabs/router/RouterClient.java
+++ b/common/classes/com/oddlabs/router/RouterClient.java
@@ -20,6 +20,7 @@ final strictfp class RouterClient implements ConnectionInterface {
     private final Router router;
     private final List checksums = new LinkedList();
     private int client_id;
+    private boolean is_spectator;
     private SessionManager.Timeout timeout;
     private Session session;
     private Interface current_interface;
@@ -43,6 +44,12 @@ final strictfp class RouterClient implements ConnectionInterface {
                                 Session session =
                                         session_manager.get(session_id, session_info, client_id);
                                 doLogin(session, session_info, client_id);
+                            }
+
+                            public final void loginSpectator(SessionID session_id) {
+                                Session session =
+                                        session_manager.getExistingSession(session_id);
+                                doLoginSpectator(session);
                             }
                         });
     }
@@ -106,6 +113,25 @@ final strictfp class RouterClient implements ConnectionInterface {
         logger.info("Player logged in: session = " + session + " client_id = " + client_id);
     }
 
+    private void doLoginSpectator(Session session) {
+        this.session = session;
+        this.is_spectator = true;
+        this.current_interface =
+                new Interface(
+                        GameInterface.class,
+                        new GameInterface() {
+                            public final void checksum(int checksum) {}
+
+                            public final void relayEventTo(int client_id, ARMIEvent event) {}
+
+                            public final void relayGameStateEvent(ARMIEvent event) {}
+
+                            public final void relayEvent(ARMIEvent event) {}
+                        });
+        session.addSpectator(this);
+        logger.info("Spectator logged in: session = " + session);
+    }
+
     private void doChecksum(int checksum) {
         checksums.add(new Integer(checksum));
         session.checksum();
@@ -162,13 +188,18 @@ final strictfp class RouterClient implements ConnectionInterface {
         connection.close();
         if (session != null) {
             logger.info("Removing client: " + this);
-            session.removePlayer(this);
-            session.visit(
-                    new SessionVisitor() {
-                        public final void visit(RouterClient client) {
-                            client.client_interface.playerDisconnected(client_id, checksum_error);
-                        }
-                    });
+            if (is_spectator) {
+                session.removeSpectator(this);
+            } else {
+                session.removePlayer(this);
+                session.visit(
+                        new SessionVisitor() {
+                            public final void visit(RouterClient client) {
+                                client.client_interface.playerDisconnected(
+                                        client_id, checksum_error);
+                            }
+                        });
+            }
         }
     }
 

--- a/common/classes/com/oddlabs/router/RouterClient.java
+++ b/common/classes/com/oddlabs/router/RouterClient.java
@@ -47,8 +47,7 @@ final strictfp class RouterClient implements ConnectionInterface {
                             }
 
                             public final void loginSpectator(SessionID session_id) {
-                                Session session =
-                                        session_manager.getExistingSession(session_id);
+                                Session session = session_manager.getExistingSession(session_id);
                                 doLoginSpectator(session);
                             }
                         });

--- a/common/classes/com/oddlabs/router/RouterInterface.java
+++ b/common/classes/com/oddlabs/router/RouterInterface.java
@@ -4,5 +4,6 @@ public strictfp interface RouterInterface {
     public static final int PORT = 11221;
 
     void login(SessionID id, SessionInfo info, int client_id);
+
     void loginSpectator(SessionID id);
 }

--- a/common/classes/com/oddlabs/router/RouterInterface.java
+++ b/common/classes/com/oddlabs/router/RouterInterface.java
@@ -4,4 +4,5 @@ public strictfp interface RouterInterface {
     public static final int PORT = 11221;
 
     void login(SessionID id, SessionInfo info, int client_id);
+    void loginSpectator(SessionID id);
 }

--- a/common/classes/com/oddlabs/router/Session.java
+++ b/common/classes/com/oddlabs/router/Session.java
@@ -15,6 +15,7 @@ final strictfp class Session {
     public final SessionID session_id;
     private final Logger logger;
     private final Set players = new HashSet();
+    private final Set spectators = new HashSet();
     private final SessionManager manager;
     private long initial_time;
 
@@ -40,7 +41,15 @@ final strictfp class Session {
 
     final void removePlayer(RouterClient client) {
         players.remove(client);
-        if (getNumPlayers() == 0) manager.remove(this);
+        if (getNumPlayers() == 0) {
+            // Kick all spectators — game is over
+            for (Iterator it = spectators.iterator(); it.hasNext(); ) {
+                RouterClient spectator = (RouterClient) it.next();
+                it.remove();
+                spectator.doError(false, new IOException("Game ended"));
+            }
+            manager.remove(this);
+        }
         checksum();
     }
 
@@ -48,7 +57,7 @@ final strictfp class Session {
         final Map checksum_to_count = new HashMap();
         final int[] best_checksum = new int[1];
         final boolean[] missing_checksum = new boolean[1];
-        visit(
+        visitPlayers(
                 new SessionVisitor() {
                     private int best_checksum_count = 0;
 
@@ -73,7 +82,7 @@ final strictfp class Session {
                 });
         if (checksum_to_count.size() == 1) return;
         final List clients_to_be_kicked = new ArrayList();
-        visit(
+        visitPlayers(
                 new SessionVisitor() {
                     public final void visit(RouterClient client) {
                         Integer client_checksum;
@@ -102,6 +111,17 @@ final strictfp class Session {
         if (info.num_participants == players.size()) start();
     }
 
+    final void addSpectator(RouterClient client) {
+        spectators.add(client);
+        client.getInterface().start();
+        manager.startTimeout(client);
+    }
+
+    final void removeSpectator(RouterClient client) {
+        spectators.remove(client);
+        if (getNumPlayers() == 0) manager.remove(this);
+    }
+
     final int getNextTick() {
         return manager.getNextTick(this);
     }
@@ -125,12 +145,22 @@ final strictfp class Session {
         return initial_time;
     }
 
+    /*	All expected participants have joined and the game has started */
     final boolean isComplete() {
         return started;
     }
 
-    final void visit(SessionVisitor visitor) {
+    final void visitPlayers(SessionVisitor visitor) {
         Iterator it = players.iterator();
+        while (it.hasNext()) {
+            RouterClient client = (RouterClient) it.next();
+            visitor.visit(client);
+        }
+    }
+
+    final void visit(SessionVisitor visitor) {
+        visitPlayers(visitor);
+        Iterator it = spectators.iterator();
         while (it.hasNext()) {
             RouterClient client = (RouterClient) it.next();
             visitor.visit(client);

--- a/common/classes/com/oddlabs/router/SessionManager.java
+++ b/common/classes/com/oddlabs/router/SessionManager.java
@@ -28,7 +28,8 @@ final strictfp class SessionManager {
             id_to_session.put(session_id, session);
             logger.info("Creating session: " + session);
         } else {
-            if (!session.info.equals(session_info)
+            if (session.isComplete()
+                    || !session.info.equals(session_info)
                     || session.hasClient(client_id)
                     || client_id >= session_info.num_participants)
                 throw new RuntimeException(
@@ -39,6 +40,14 @@ final strictfp class SessionManager {
                                 + " client_id = "
                                 + client_id);
         }
+        return session;
+    }
+
+    final Session getExistingSession(SessionID session_id) {
+        Session session = (Session) id_to_session.get(session_id);
+        if (session == null || !session.isComplete())
+            throw new RuntimeException(
+                    "Session not found or not started for spectator: " + session_id);
         return session;
     }
 
@@ -92,7 +101,6 @@ final strictfp class SessionManager {
     }
 
     final long start(Session session) {
-        remove(session);
         final long initial_time = time_manager.getMillis();
         session.visit(
                 new SessionVisitor() {
@@ -127,7 +135,8 @@ final strictfp class SessionManager {
     }
 
     public final void startTimeout(RouterClient client) {
-        unregister(client.getTimeout());
+        if (client.getTimeout() != null)
+            unregister(client.getTimeout());
         long millis = time_manager.getMillis();
         Timeout timeout = createTimeout(client, millis);
         client.setTimeout(timeout);

--- a/common/classes/com/oddlabs/router/SessionManager.java
+++ b/common/classes/com/oddlabs/router/SessionManager.java
@@ -135,8 +135,7 @@ final strictfp class SessionManager {
     }
 
     public final void startTimeout(RouterClient client) {
-        if (client.getTimeout() != null)
-            unregister(client.getTimeout());
+        if (client.getTimeout() != null) unregister(client.getTimeout());
         long millis = time_manager.getMillis();
         Timeout timeout = createTimeout(client, millis);
         client.setTimeout(timeout);

--- a/server/classes/com/oddlabs/matchserver/Client.java
+++ b/server/classes/com/oddlabs/matchserver/Client.java
@@ -211,7 +211,8 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
         getGameSession().updateGameStatus(tick, status);
     }
 
-    public final void updateCommandEvent(int tick, int client_id, short event_size, byte[] event_data) {
+    public final void updateCommandEvent(
+            int tick, int client_id, short event_size, byte[] event_data) {
         if (getGameSession() == null) return;
         getGameSession().updateCommandEvent(tick, client_id, event_size, event_data);
     }
@@ -729,7 +730,10 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
         byte[] world_params_data = game_session.getWorldParamsData();
         if (world_params_data == null) {
             MatchmakingServer.getLogger()
-                    .warning("Game " + game_session.getDatabaseID() + ": no world params available for spectating");
+                    .warning(
+                            "Game "
+                                    + game_session.getDatabaseID()
+                                    + ": no world params available for spectating");
             getClientInterface().error(MatchmakingClientInterface.CHAT_ERROR_NO_SUCH_NICK);
             return;
         }

--- a/server/classes/com/oddlabs/matchserver/Client.java
+++ b/server/classes/com/oddlabs/matchserver/Client.java
@@ -747,8 +747,9 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
                                 + world_params_data.length
                                 + " bytes");
         // Send world params only. The spectator will request the event log
-        // after connecting to the router so there are no 
-        // gaps in the event log between sending the world params and the spectator connecting to the router.
+        // after connecting to the router so there are no
+        // gaps in the event log between sending the world params and the spectator connecting to
+        // the router.
         getClientInterface().receiveSpectatorData(world_params_data);
     }
 

--- a/server/classes/com/oddlabs/matchserver/Client.java
+++ b/server/classes/com/oddlabs/matchserver/Client.java
@@ -211,6 +211,11 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
         getGameSession().updateGameStatus(tick, status);
     }
 
+    public final void updateCommandEvent(int tick, int client_id, short event_size, byte[] event_data) {
+        if (getGameSession() == null) return;
+        getGameSession().updateCommandEvent(tick, client_id, event_size, event_data);
+    }
+
     public final void updateSpectatorInfo(int tick, String info) {
         if (getGameSession() == null) return;
         getGameSession().updateSpectatorInfo(tick, info);
@@ -696,6 +701,27 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
                 getClientInterface().error(MatchmakingClientInterface.CHAT_ERROR_NO_SUCH_NICK);
             }
         }
+    }
+
+    public final void requestSpectate(String nick) {
+        Client client = (Client) active_clients.get(nick.toLowerCase());
+        if (client == null || !client.isPlaying()) {
+            getClientInterface().error(MatchmakingClientInterface.CHAT_ERROR_NO_SUCH_NICK);
+            return;
+        }
+        TimestampedGameSession game_session = client.getGameSession();
+        if (game_session == null) {
+            getClientInterface().error(MatchmakingClientInterface.CHAT_ERROR_NO_SUCH_NICK);
+            return;
+        }
+        MatchmakingServer.getLogger()
+                .info(
+                        getUsername()
+                                + " requested to spectate "
+                                + nick
+                                + " in game "
+                                + game_session.getDatabaseID());
+        // TODO Phase 2: Send world params + event log to requesting client
     }
 
     private String formatChat(String message) {

--- a/server/classes/com/oddlabs/matchserver/Client.java
+++ b/server/classes/com/oddlabs/matchserver/Client.java
@@ -57,6 +57,7 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
 
     private Game current_game;
     private TimestampedGameSession current_session;
+    private TimestampedGameSession spectated_session;
     private ChatRoom current_room;
 
     public Client(
@@ -737,19 +738,35 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
             getClientInterface().error(MatchmakingClientInterface.CHAT_ERROR_NO_SUCH_NICK);
             return;
         }
-        byte[] event_log_data = game_session.readEventLog();
-        int current_tick = game_session.getLastTick();
+        this.spectated_session = game_session;
         MatchmakingServer.getLogger()
                 .info(
-                        "Sending spectate data for game "
+                        "Sending spectate setup for game "
                                 + game_session.getDatabaseID()
                                 + ": world_params="
                                 + world_params_data.length
-                                + " bytes, event_log="
+                                + " bytes");
+        // Send world params only. The spectator will request the event log
+        // after connecting to the router so there are no 
+        // gaps in the event log between sending the world params and the spectator connecting to the router.
+        getClientInterface().receiveSpectatorData(world_params_data);
+    }
+
+    public final void requestSpectatorEventLog() {
+        if (spectated_session == null) {
+            return;
+        }
+        byte[] event_log_data = spectated_session.readEventLog();
+        int current_tick = spectated_session.getLastTick();
+        MatchmakingServer.getLogger()
+                .info(
+                        "Sending spectator event log for game "
+                                + spectated_session.getDatabaseID()
+                                + ": event_log="
                                 + event_log_data.length
                                 + " bytes, tick="
                                 + current_tick);
-        getClientInterface().receiveSpectatorData(world_params_data, event_log_data, current_tick);
+        getClientInterface().receiveSpectatorEventLog(event_log_data, current_tick);
     }
 
     private String formatChat(String message) {

--- a/server/classes/com/oddlabs/matchserver/Client.java
+++ b/server/classes/com/oddlabs/matchserver/Client.java
@@ -216,6 +216,11 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
         getGameSession().updateCommandEvent(tick, client_id, event_size, event_data);
     }
 
+    public final void updateWorldParams(byte[] world_params_data) {
+        if (getGameSession() == null) return;
+        getGameSession().updateWorldParams(world_params_data);
+    }
+
     public final void updateSpectatorInfo(int tick, String info) {
         if (getGameSession() == null) return;
         getGameSession().updateSpectatorInfo(tick, info);

--- a/server/classes/com/oddlabs/matchserver/Client.java
+++ b/server/classes/com/oddlabs/matchserver/Client.java
@@ -768,6 +768,7 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
                                 + " bytes, tick="
                                 + current_tick);
         getClientInterface().receiveSpectatorEventLog(event_log_data, current_tick);
+        this.spectated_session = null;
     }
 
     private String formatChat(String message) {

--- a/server/classes/com/oddlabs/matchserver/Client.java
+++ b/server/classes/com/oddlabs/matchserver/Client.java
@@ -726,7 +726,26 @@ public final strictfp class Client implements MatchmakingServerInterface, Connec
                                 + nick
                                 + " in game "
                                 + game_session.getDatabaseID());
-        // TODO Phase 2: Send world params + event log to requesting client
+        byte[] world_params_data = game_session.getWorldParamsData();
+        if (world_params_data == null) {
+            MatchmakingServer.getLogger()
+                    .warning("Game " + game_session.getDatabaseID() + ": no world params available for spectating");
+            getClientInterface().error(MatchmakingClientInterface.CHAT_ERROR_NO_SUCH_NICK);
+            return;
+        }
+        byte[] event_log_data = game_session.readEventLog();
+        int current_tick = game_session.getLastTick();
+        MatchmakingServer.getLogger()
+                .info(
+                        "Sending spectate data for game "
+                                + game_session.getDatabaseID()
+                                + ": world_params="
+                                + world_params_data.length
+                                + " bytes, event_log="
+                                + event_log_data.length
+                                + " bytes, tick="
+                                + current_tick);
+        getClientInterface().receiveSpectatorData(world_params_data, event_log_data, current_tick);
     }
 
     private String formatChat(String message) {

--- a/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
+++ b/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
@@ -5,7 +5,9 @@ import com.oddlabs.matchmaking.MatchmakingServerInterface;
 import com.oddlabs.matchmaking.Participant;
 import com.oddlabs.matchserver.discord.DiscordEmbedCreator;
 
+import java.io.DataOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.sql.SQLException;
 import java.util.HashSet;
@@ -54,6 +56,9 @@ public final strictfp class TimestampedGameSession {
     private FileWriter spectator_file_writer;
     private HashSet info_written;
 
+    private File command_event_file;
+    private DataOutputStream command_event_stream;
+
     public TimestampedGameSession(GameSession session, int database_id) {
         this.session = session;
         this.database_id = database_id;
@@ -73,11 +78,21 @@ public final strictfp class TimestampedGameSession {
                                 + "] "
                                 + getParticipantStates());
         info_written = new HashSet();
+        File games_dir = new File("/var/games/");
+        if (!games_dir.exists()) {
+            games_dir.mkdirs();
+        }
         try {
-            spectator_file = new File("/var/games/" + database_id);
+            spectator_file = new File(games_dir, String.valueOf(database_id));
             spectator_file_writer = new FileWriter(spectator_file);
         } catch (Exception e) {
             System.out.println("An exception while creating spectator file: " + e);
+        }
+        try {
+            command_event_file = new File(games_dir, database_id + ".events");
+            command_event_stream = new DataOutputStream(new FileOutputStream(command_event_file));
+        } catch (Exception e) {
+            System.out.println("An exception while creating command event file: " + e);
         }
     }
 
@@ -199,6 +214,21 @@ public final strictfp class TimestampedGameSession {
             }
         } catch (Exception e) {
             System.out.println("Exception during writing spectator file: " + e);
+        }
+    }
+
+    public final void updateCommandEvent(int tick, int client_id, short event_size, byte[] event_data) {
+        if (command_event_stream == null) {
+            return;
+        }
+        try {
+            command_event_stream.writeInt(tick);
+            command_event_stream.writeInt(client_id);
+            command_event_stream.writeShort(event_size);
+            command_event_stream.write(event_data, 0, event_size);
+            command_event_stream.flush();
+        } catch (Exception e) {
+            System.out.println("Exception during writing command event file: " + e);
         }
     }
 

--- a/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
+++ b/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
@@ -7,6 +7,7 @@ import com.oddlabs.matchserver.discord.DiscordEmbedCreator;
 
 import java.io.DataOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.sql.SQLException;
@@ -228,9 +229,39 @@ public final strictfp class TimestampedGameSession {
         return world_params_data;
     }
 
+    public final int getLastTick() {
+        return last_tick;
+    }
+
+    public final byte[] readEventLog() {
+        if (command_event_file == null || !command_event_file.exists()) {
+            return new byte[0];
+        }
+        try {
+            command_event_stream.flush();
+            long length = command_event_file.length();
+            byte[] data = new byte[(int) length];
+            FileInputStream fis = new FileInputStream(command_event_file);
+            int offset = 0;
+            while (offset < data.length) {
+                int read = fis.read(data, offset, data.length - offset);
+                if (read == -1) break;
+                offset += read;
+            }
+            fis.close();
+            return data;
+        } catch (Exception e) {
+            MatchmakingServer.getLogger().warning("Exception reading event log: " + e);
+            return new byte[0];
+        }
+    }
+
     public final void updateCommandEvent(int tick, int client_id, short event_size, byte[] event_data) {
         if (command_event_stream == null) {
             return;
+        }
+        if (tick > last_tick) {
+            last_tick = tick;
         }
         try {
             command_event_stream.writeInt(tick);

--- a/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
+++ b/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
@@ -244,14 +244,17 @@ public final strictfp class TimestampedGameSession {
             long length = command_event_file.length();
             byte[] data = new byte[(int) length];
             FileInputStream fis = new FileInputStream(command_event_file);
-            int offset = 0;
-            while (offset < data.length) {
-                int read = fis.read(data, offset, data.length - offset);
-                if (read == -1) break;
-                offset += read;
+            try {
+                int offset = 0;
+                while (offset < data.length) {
+                    int read = fis.read(data, offset, data.length - offset);
+                    if (read == -1) break;
+                    offset += read;
+                }
+                return data;
+            } finally {
+                fis.close();
             }
-            fis.close();
-            return data;
         } catch (Exception e) {
             MatchmakingServer.getLogger().warning("Exception reading event log: " + e);
             return new byte[0];

--- a/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
+++ b/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
@@ -238,7 +238,9 @@ public final strictfp class TimestampedGameSession {
             return new byte[0];
         }
         try {
-            command_event_stream.flush();
+            if (command_event_stream != null) {
+                command_event_stream.flush();
+            }
             long length = command_event_file.length();
             byte[] data = new byte[(int) length];
             FileInputStream fis = new FileInputStream(command_event_file);
@@ -259,6 +261,10 @@ public final strictfp class TimestampedGameSession {
     public final void updateCommandEvent(
             int tick, int client_id, short event_size, byte[] event_data) {
         if (command_event_stream == null) {
+            return;
+        }
+        if (event_size <= 0 || event_size > event_data.length) {
+            System.out.println("Invalid event_size: " + event_size);
             return;
         }
         if (tick > last_tick) {
@@ -491,6 +497,12 @@ public final strictfp class TimestampedGameSession {
 
     protected final void finalize() {
         if (!game_ended) DBInterface.endGame(this, System.currentTimeMillis(), -1);
+        try {
+            if (command_event_stream != null) command_event_stream.close();
+            if (spectator_file_writer != null) spectator_file_writer.close();
+        } catch (Exception e) {
+            System.out.println("Error closing spectator streams: " + e);
+        }
     }
 
     private final void teamWon(MatchmakingServer server, int[] team_result) {

--- a/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
+++ b/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
@@ -58,6 +58,7 @@ public final strictfp class TimestampedGameSession {
 
     private File command_event_file;
     private DataOutputStream command_event_stream;
+    private byte[] world_params_data;
 
     public TimestampedGameSession(GameSession session, int database_id) {
         this.session = session;
@@ -215,6 +216,16 @@ public final strictfp class TimestampedGameSession {
         } catch (Exception e) {
             System.out.println("Exception during writing spectator file: " + e);
         }
+    }
+
+    public final void updateWorldParams(byte[] data) {
+        this.world_params_data = data;
+        MatchmakingServer.getLogger()
+                .info("Game " + database_id + ": world params stored (" + data.length + " bytes)");
+    }
+
+    public final byte[] getWorldParamsData() {
+        return world_params_data;
     }
 
     public final void updateCommandEvent(int tick, int client_id, short event_size, byte[] event_data) {

--- a/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
+++ b/server/classes/com/oddlabs/matchserver/TimestampedGameSession.java
@@ -256,7 +256,8 @@ public final strictfp class TimestampedGameSession {
         }
     }
 
-    public final void updateCommandEvent(int tick, int client_id, short event_size, byte[] event_data) {
+    public final void updateCommandEvent(
+            int tick, int client_id, short event_size, byte[] event_data) {
         if (command_event_stream == null) {
             return;
         }

--- a/tt/classes/com/oddlabs/tt/form/ChatErrorForm.java
+++ b/tt/classes/com/oddlabs/tt/form/ChatErrorForm.java
@@ -15,6 +15,8 @@ public final strictfp class ChatErrorForm extends MessageForm {
                 return Utils.getBundleString(bundle, "chat_error_invalid_name");
             case MatchmakingClientInterface.CHAT_ERROR_NO_SUCH_NICK:
                 return Utils.getBundleString(bundle, "chat_error_no_such_nick");
+            case MatchmakingClientInterface.CHAT_ERROR_SPECTATE_FAILED:
+                return Utils.getBundleString(bundle, "chat_error_spectate_failed");
             default:
                 throw new RuntimeException("Unknown error code: " + error_code);
         }

--- a/tt/classes/com/oddlabs/tt/gui/ChatPanel.java
+++ b/tt/classes/com/oddlabs/tt/gui/ChatPanel.java
@@ -9,10 +9,16 @@ import com.oddlabs.tt.util.Utils;
 import java.util.*;
 
 public strictfp class ChatPanel extends Panel implements ChatListener {
-    private static final int PULLDOWN_INDEX_MESSAGE = 0;
-    private static final int PULLDOWN_INDEX_INFO = 1;
-    private static final int PULLDOWN_INDEX_IGNORE = 2;
-    private static final int PULLDOWN_INDEX_SPECTATE = 3;
+    // Lobby menu: Message, Info, Ignore
+    private static final int LOBBY_MESSAGE = 0;
+    private static final int LOBBY_INFO = 1;
+    private static final int LOBBY_IGNORE = 2;
+
+    // Playing menu: Message, Info, Spectate, Ignore
+    private static final int PLAYING_MESSAGE = 0;
+    private static final int PLAYING_INFO = 1;
+    private static final int PLAYING_SPECTATE = 2;
+    private static final int PLAYING_IGNORE = 3;
 
     private final MultiColumnComboBox lobby_users_list_box;
     private final MultiColumnComboBox playing_users_list_box;
@@ -85,24 +91,24 @@ public strictfp class ChatPanel extends Panel implements ChatListener {
         PulldownMenu lobby_pulldown_menu = new PulldownMenu();
         lobby_pulldown_menu.addItem(new PulldownItem(getI18N("message")));
         lobby_pulldown_menu.addItem(new PulldownItem(getI18N("info")));
-        lobby_pulldown_menu.addItem(new PulldownItem(""));
-        lobby_pulldown_menu.addItemChosenListener(new PulldownListener(lobby_users_list_box));
+        lobby_pulldown_menu.addItem(new PulldownItem(getI18N("ignore")));
+        lobby_pulldown_menu.addItemChosenListener(new LobbyPulldownListener(lobby_users_list_box));
         lobby_users_list_box.setPulldownMenu(lobby_pulldown_menu);
 
         ChatRoomUserDoubleClickedListener lobby_double_clicked =
-                new ChatRoomUserDoubleClickedListener(lobby_pulldown_menu);
+                new ChatRoomUserDoubleClickedListener(lobby_pulldown_menu, LOBBY_IGNORE);
         lobby_users_list_box.addRowListener(lobby_double_clicked);
 
         PulldownMenu playing_pulldown_menu = new PulldownMenu();
         playing_pulldown_menu.addItem(new PulldownItem(getI18N("message")));
         playing_pulldown_menu.addItem(new PulldownItem(getI18N("info")));
-        playing_pulldown_menu.addItem(new PulldownItem(""));
         playing_pulldown_menu.addItem(new PulldownItem(getI18N("spectate")));
-        playing_pulldown_menu.addItemChosenListener(new PulldownListener(playing_users_list_box));
+        playing_pulldown_menu.addItem(new PulldownItem(getI18N("ignore")));
+        playing_pulldown_menu.addItemChosenListener(new PlayingPulldownListener(playing_users_list_box));
         playing_users_list_box.setPulldownMenu(playing_pulldown_menu);
 
         ChatRoomUserDoubleClickedListener playing_double_clicked =
-                new ChatRoomUserDoubleClickedListener(playing_pulldown_menu);
+                new ChatRoomUserDoubleClickedListener(playing_pulldown_menu, PLAYING_IGNORE);
         playing_users_list_box.addRowListener(playing_double_clicked);
 
         int width =
@@ -206,10 +212,10 @@ public strictfp class ChatPanel extends Panel implements ChatListener {
         }
     }
 
-    private final strictfp class PulldownListener implements ItemChosenListener {
+    private final strictfp class LobbyPulldownListener implements ItemChosenListener {
         private final MultiColumnComboBox box;
 
-        public PulldownListener(MultiColumnComboBox box) {
+        public LobbyPulldownListener(MultiColumnComboBox box) {
             this.box = box;
         }
 
@@ -217,22 +223,47 @@ public strictfp class ChatPanel extends Panel implements ChatListener {
             ChatRoomUser user = (ChatRoomUser) box.getRightClickedRowData();
             String nick = user.getNick();
             switch (item_index) {
-                case PULLDOWN_INDEX_MESSAGE:
+                case LOBBY_MESSAGE:
                     gui_root.addModalForm(new PrivateMessageForm(gui_root, nick));
                     break;
-                case PULLDOWN_INDEX_INFO:
+                case LOBBY_INFO:
                     Network.getMatchmakingClient().requestInfo(gui_root, nick);
                     break;
-                case PULLDOWN_INDEX_IGNORE:
+                case LOBBY_IGNORE:
                     if (ChatCommand.isIgnoring(nick))
                         ChatCommand.unignore(gui_root.getInfoPrinter(), nick);
                     else ChatCommand.ignore(gui_root.getInfoPrinter(), nick);
                     break;
-                case PULLDOWN_INDEX_SPECTATE:
+            }
+            box.setFocus();
+        }
+    }
+
+    private final strictfp class PlayingPulldownListener implements ItemChosenListener {
+        private final MultiColumnComboBox box;
+
+        public PlayingPulldownListener(MultiColumnComboBox box) {
+            this.box = box;
+        }
+
+        public final void itemChosen(PulldownMenu menu, int item_index) {
+            ChatRoomUser user = (ChatRoomUser) box.getRightClickedRowData();
+            String nick = user.getNick();
+            switch (item_index) {
+                case PLAYING_MESSAGE:
+                    gui_root.addModalForm(new PrivateMessageForm(gui_root, nick));
+                    break;
+                case PLAYING_INFO:
+                    Network.getMatchmakingClient().requestInfo(gui_root, nick);
+                    break;
+                case PLAYING_SPECTATE:
                     Network.getMatchmakingClient().requestSpectate(gui_root, nick);
                     break;
-                default:
-                    throw new RuntimeException();
+                case PLAYING_IGNORE:
+                    if (ChatCommand.isIgnoring(nick))
+                        ChatCommand.unignore(gui_root.getInfoPrinter(), nick);
+                    else ChatCommand.ignore(gui_root.getInfoPrinter(), nick);
+                    break;
             }
             box.setFocus();
         }
@@ -240,9 +271,11 @@ public strictfp class ChatPanel extends Panel implements ChatListener {
 
     private final strictfp class ChatRoomUserDoubleClickedListener implements RowListener {
         private final PulldownMenu menu;
+        private final int ignore_index;
 
-        public ChatRoomUserDoubleClickedListener(PulldownMenu menu) {
+        public ChatRoomUserDoubleClickedListener(PulldownMenu menu, int ignore_index) {
             this.menu = menu;
+            this.ignore_index = ignore_index;
         }
 
         public final void rowDoubleClicked(Object context) {
@@ -256,7 +289,7 @@ public strictfp class ChatPanel extends Panel implements ChatListener {
             String item_text;
             if (ChatCommand.isIgnoring(user.getNick())) item_text = getI18N("unignore");
             else item_text = getI18N("ignore");
-            menu.getItem(PULLDOWN_INDEX_IGNORE).setLabelString(item_text);
+            menu.getItem(ignore_index).setLabelString(item_text);
         }
     }
 }

--- a/tt/classes/com/oddlabs/tt/gui/ChatPanel.java
+++ b/tt/classes/com/oddlabs/tt/gui/ChatPanel.java
@@ -104,7 +104,8 @@ public strictfp class ChatPanel extends Panel implements ChatListener {
         playing_pulldown_menu.addItem(new PulldownItem(getI18N("info")));
         playing_pulldown_menu.addItem(new PulldownItem(getI18N("spectate")));
         playing_pulldown_menu.addItem(new PulldownItem(getI18N("ignore")));
-        playing_pulldown_menu.addItemChosenListener(new PlayingPulldownListener(playing_users_list_box));
+        playing_pulldown_menu.addItemChosenListener(
+                new PlayingPulldownListener(playing_users_list_box));
         playing_users_list_box.setPulldownMenu(playing_pulldown_menu);
 
         ChatRoomUserDoubleClickedListener playing_double_clicked =

--- a/tt/classes/com/oddlabs/tt/gui/ChatPanel.java
+++ b/tt/classes/com/oddlabs/tt/gui/ChatPanel.java
@@ -12,6 +12,7 @@ public strictfp class ChatPanel extends Panel implements ChatListener {
     private static final int PULLDOWN_INDEX_MESSAGE = 0;
     private static final int PULLDOWN_INDEX_INFO = 1;
     private static final int PULLDOWN_INDEX_IGNORE = 2;
+    private static final int PULLDOWN_INDEX_SPECTATE = 3;
 
     private final MultiColumnComboBox lobby_users_list_box;
     private final MultiColumnComboBox playing_users_list_box;
@@ -96,6 +97,7 @@ public strictfp class ChatPanel extends Panel implements ChatListener {
         playing_pulldown_menu.addItem(new PulldownItem(getI18N("message")));
         playing_pulldown_menu.addItem(new PulldownItem(getI18N("info")));
         playing_pulldown_menu.addItem(new PulldownItem(""));
+        playing_pulldown_menu.addItem(new PulldownItem(getI18N("spectate")));
         playing_pulldown_menu.addItemChosenListener(new PulldownListener(playing_users_list_box));
         playing_users_list_box.setPulldownMenu(playing_pulldown_menu);
 
@@ -225,6 +227,9 @@ public strictfp class ChatPanel extends Panel implements ChatListener {
                     if (ChatCommand.isIgnoring(nick))
                         ChatCommand.unignore(gui_root.getInfoPrinter(), nick);
                     else ChatCommand.ignore(gui_root.getInfoPrinter(), nick);
+                    break;
+                case PULLDOWN_INDEX_SPECTATE:
+                    Network.getMatchmakingClient().requestSpectate(gui_root, nick);
                     break;
                 default:
                     throw new RuntimeException();

--- a/tt/classes/com/oddlabs/tt/landscape/WorldParameters.java
+++ b/tt/classes/com/oddlabs/tt/landscape/WorldParameters.java
@@ -1,6 +1,9 @@
 package com.oddlabs.tt.landscape;
 
-public final strictfp class WorldParameters {
+import java.io.Serializable;
+
+public final strictfp class WorldParameters implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final String map_code;
     private final int initial_unit_count;
     private final int max_unit_count;

--- a/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
@@ -254,8 +254,7 @@ public final strictfp class MatchmakingClient
         getInterface().requestSpectate(nick);
     }
 
-    public final void receiveSpectatorData(
-            byte[] world_params_data, byte[] event_log_data, int current_tick) {
+    public final void receiveSpectatorData(byte[] world_params_data) {
         if (chat_gui_root == null || network == null) return;
 
         try {
@@ -271,6 +270,7 @@ public final strictfp class MatchmakingClient
             ois.close();
 
             // Launch ReplayWorldStarter with spectator InGameInfo
+            // Event log is requested later by PeerHub after router connection
             GUI gui = chat_gui_root.getGUI();
             ProgressForm.setProgressForm(
                     network,
@@ -284,14 +284,19 @@ public final strictfp class MatchmakingClient
                             unit_infos,
                             (short) 0, // player_slot — view from player 0
                             new SpectatorInGameInfo(random_start_position),
-                            new SpectatorWorldInitAction(),
-                            event_log_data,
-                            current_tick));
+                            new SpectatorWorldInitAction()));
 
             chat_gui_root = null;
         } catch (Exception e) {
             System.out.println("Failed to deserialize spectator data: " + e);
             error(MatchmakingClientInterface.CHAT_ERROR_SPECTATE_FAILED);
+        }
+    }
+
+    public final void receiveSpectatorEventLog(byte[] event_log_data, int current_tick) {
+        PeerHub spectator = PeerHub.getSpectatorInstance();
+        if (spectator != null && event_log_data != null && event_log_data.length > 0) {
+            spectator.fastForward(event_log_data, current_tick);
         }
     }
 

--- a/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
@@ -266,6 +266,7 @@ public final strictfp class MatchmakingClient
             PlayerSlot[] player_slots = (PlayerSlot[]) ois.readObject();
             UnitInfo[] unit_infos = (UnitInfo[]) ois.readObject();
             float random_start_position = ois.readFloat();
+            int session_id = ois.readInt();
             ois.close();
 
             // Launch ReplayWorldStarter with spectator InGameInfo
@@ -275,7 +276,7 @@ public final strictfp class MatchmakingClient
                     gui,
                     new ReplayWorldStarter(
                             network,
-                            0, // session_id placeholder — spectator has no Router session yet
+                            session_id,
                             generator,
                             world_params,
                             player_slots,

--- a/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
@@ -245,6 +245,12 @@ public final strictfp class MatchmakingClient
         getInterface().requestSpectate(nick);
     }
 
+    public final void receiveSpectatorData(byte[] world_params_data, byte[] event_log_data, int current_tick) {
+        System.out.println("Received spectator data: world_params=" + world_params_data.length
+                + " bytes, event_log=" + event_log_data.length + " bytes, tick=" + current_tick);
+        // TODO Phase 2.2: Deserialize world params, create ReplayWorldStarter, begin fast-forward
+    }
+
     public final void receiveInfo(Profile profile) {
         if (chat_gui_root != null) {
             chat_gui_root.addModalForm(new InfoForm(profile));

--- a/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
@@ -265,6 +265,7 @@ public final strictfp class MatchmakingClient
             WorldParameters world_params = (WorldParameters) ois.readObject();
             PlayerSlot[] player_slots = (PlayerSlot[]) ois.readObject();
             UnitInfo[] unit_infos = (UnitInfo[]) ois.readObject();
+            float random_start_position = ois.readFloat();
             ois.close();
 
             // Launch WorldStarter with spectator InGameInfo
@@ -280,7 +281,7 @@ public final strictfp class MatchmakingClient
                             player_slots,
                             unit_infos,
                             (short) 0, // player_slot — view from player 0
-                            new SpectatorInGameInfo(),
+                            new SpectatorInGameInfo(random_start_position),
                             new SpectatorWorldInitAction()));
 
             chat_gui_root = null;

--- a/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
@@ -254,7 +254,8 @@ public final strictfp class MatchmakingClient
         getInterface().requestSpectate(nick);
     }
 
-    public final void receiveSpectatorData(byte[] world_params_data, byte[] event_log_data, int current_tick) {
+    public final void receiveSpectatorData(
+            byte[] world_params_data, byte[] event_log_data, int current_tick) {
         if (chat_gui_root == null || network == null) return;
 
         try {

--- a/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
@@ -281,7 +281,7 @@ public final strictfp class MatchmakingClient
                             unit_infos,
                             (short) 0, // player_slot — view from player 0
                             new SpectatorInGameInfo(),
-                            null)); // no initial_action
+                            new SpectatorWorldInitAction()));
 
             chat_gui_root = null;
         } catch (Exception e) {

--- a/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
@@ -19,14 +19,22 @@ import com.oddlabs.net.NetworkSelector;
 import com.oddlabs.net.SecureConnection;
 import com.oddlabs.tt.form.ChatErrorForm;
 import com.oddlabs.tt.form.InfoForm;
+import com.oddlabs.tt.form.ProgressForm;
 import com.oddlabs.tt.global.Settings;
 import com.oddlabs.tt.gui.ChatRoomInfo;
+import com.oddlabs.tt.gui.GUI;
 import com.oddlabs.tt.gui.GUIRoot;
+import com.oddlabs.tt.landscape.WorldParameters;
+import com.oddlabs.tt.player.UnitInfo;
 import com.oddlabs.tt.render.Renderer;
+import com.oddlabs.tt.resource.WorldGenerator;
 import com.oddlabs.tt.util.Utils;
+import com.oddlabs.tt.viewer.SpectatorInGameInfo;
 import com.oddlabs.util.Compatibility;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -47,6 +55,7 @@ public final strictfp class MatchmakingClient
             new ARMIInterfaceMethods(MatchmakingClientInterface.class);
     private final ChatRoomHistory chat_room_history;
     private final InGameChatHistory in_game_chat_history;
+    private NetworkSelector network;
     private GUIRoot chat_gui_root;
     private int current_seq_id = 1;
     private SecureConnection conn;
@@ -246,9 +255,39 @@ public final strictfp class MatchmakingClient
     }
 
     public final void receiveSpectatorData(byte[] world_params_data, byte[] event_log_data, int current_tick) {
-        System.out.println("Received spectator data: world_params=" + world_params_data.length
-                + " bytes, event_log=" + event_log_data.length + " bytes, tick=" + current_tick);
-        // TODO Phase 2.2: Deserialize world params, create ReplayWorldStarter, begin fast-forward
+        if (chat_gui_root == null || network == null) return;
+
+        try {
+            // Deserialize world params (same order as WorldStarter.sendWorldParams)
+            ByteArrayInputStream bais = new ByteArrayInputStream(world_params_data);
+            ObjectInputStream ois = new ObjectInputStream(bais);
+            WorldGenerator generator = (WorldGenerator) ois.readObject();
+            WorldParameters world_params = (WorldParameters) ois.readObject();
+            PlayerSlot[] player_slots = (PlayerSlot[]) ois.readObject();
+            UnitInfo[] unit_infos = (UnitInfo[]) ois.readObject();
+            ois.close();
+
+            // Launch WorldStarter with spectator InGameInfo
+            GUI gui = chat_gui_root.getGUI();
+            ProgressForm.setProgressForm(
+                    network,
+                    gui,
+                    new WorldStarter(
+                            network,
+                            0, // session_id placeholder — spectator has no Router session yet
+                            generator,
+                            world_params,
+                            player_slots,
+                            unit_infos,
+                            (short) 0, // player_slot — view from player 0
+                            new SpectatorInGameInfo(),
+                            null)); // no initial_action
+
+            chat_gui_root = null;
+        } catch (Exception e) {
+            System.out.println("Failed to deserialize spectator data: " + e);
+            error(MatchmakingClientInterface.CHAT_ERROR_SPECTATE_FAILED);
+        }
     }
 
     public final void receiveInfo(Profile profile) {
@@ -280,6 +319,7 @@ public final strictfp class MatchmakingClient
 
     private final void open(NetworkSelector network) {
         close();
+        this.network = network;
         this.conn =
                 new SecureConnection(
                         network.getDeterministic(),

--- a/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
@@ -268,12 +268,12 @@ public final strictfp class MatchmakingClient
             float random_start_position = ois.readFloat();
             ois.close();
 
-            // Launch WorldStarter with spectator InGameInfo
+            // Launch ReplayWorldStarter with spectator InGameInfo
             GUI gui = chat_gui_root.getGUI();
             ProgressForm.setProgressForm(
                     network,
                     gui,
-                    new WorldStarter(
+                    new ReplayWorldStarter(
                             network,
                             0, // session_id placeholder — spectator has no Router session yet
                             generator,
@@ -282,7 +282,9 @@ public final strictfp class MatchmakingClient
                             unit_infos,
                             (short) 0, // player_slot — view from player 0
                             new SpectatorInGameInfo(random_start_position),
-                            new SpectatorWorldInitAction()));
+                            new SpectatorWorldInitAction(),
+                            event_log_data,
+                            current_tick));
 
             chat_gui_root = null;
         } catch (Exception e) {

--- a/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/classes/com/oddlabs/tt/net/MatchmakingClient.java
@@ -240,6 +240,11 @@ public final strictfp class MatchmakingClient
         getInterface().requestInfo(nick);
     }
 
+    public final void requestSpectate(GUIRoot gui_root, String nick) {
+        this.chat_gui_root = gui_root;
+        getInterface().requestSpectate(nick);
+    }
+
     public final void receiveInfo(Profile profile) {
         if (chat_gui_root != null) {
             chat_gui_root.addModalForm(new InfoForm(profile));

--- a/tt/classes/com/oddlabs/tt/net/NoOpPlayerInterface.java
+++ b/tt/classes/com/oddlabs/tt/net/NoOpPlayerInterface.java
@@ -1,0 +1,42 @@
+package com.oddlabs.tt.net;
+
+import com.oddlabs.tt.model.Building;
+import com.oddlabs.tt.model.Selectable;
+import com.oddlabs.tt.model.Unit;
+import com.oddlabs.tt.player.PlayerInterface;
+import com.oddlabs.tt.util.Target;
+
+public final strictfp class NoOpPlayerInterface implements PlayerInterface {
+    public void deployUnits(Building building, int type, int num_units) {}
+
+    public void createHarvesters(
+            Building building, int num_tree, int num_rock, int num_iron, int num_rubber) {}
+
+    public void buildRockWeapons(Building building, int num_weapons, boolean infinite) {}
+
+    public void buildIronWeapons(Building building, int num_weapons, boolean infinite) {}
+
+    public void buildRubberWeapons(Building building, int num_weapons, boolean infinite) {}
+
+    public void doMagic(Unit chieftain, int magic) {}
+
+    public void exitTower(Building building) {}
+
+    public void trainChieftain(Building building, boolean start) {}
+
+    public void placeBuilding(
+            Selectable[] selection, int template_id, int placing_grid_x, int placing_grid_y) {}
+
+    public void setRallyPoint(Building building, Target target) {}
+
+    public void setTarget(Selectable[] selection, Target target, int action, boolean aggressive) {}
+
+    public void setRallyPoint(Building building, int grid_x, int grid_y) {}
+
+    public void setLandscapeTarget(
+            Selectable[] selection, int grid_x, int grid_y, int action, boolean aggressive) {}
+
+    public void setPreferredGamespeed(int speed) {}
+
+    public void changePreferredGamespeed(int delta) {}
+}

--- a/tt/classes/com/oddlabs/tt/net/PeerHub.java
+++ b/tt/classes/com/oddlabs/tt/net/PeerHub.java
@@ -71,6 +71,7 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
     private final AnimationManager manager;
     private final boolean is_multiplayer;
     private final boolean is_rated;
+    private final boolean is_spectator;
     private final StallHandler stall_handler;
     private int local_peer_index;
 
@@ -98,8 +99,10 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
             NotificationManager notification_manager,
             DistributableTable distributable_table,
             SessionID session_id,
-            StallHandler stall_handler) {
+            StallHandler stall_handler,
+            boolean is_spectator) {
         this.stall_handler = stall_handler;
+        this.is_spectator = is_spectator;
         this.is_rated = is_rated;
         this.local_player = local_player;
         this.network = network;
@@ -165,12 +168,16 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
                         router_client.getInterface().relayGameStateEvent(event);
                     }
                 };
-        this.player_interface =
-                (PlayerInterface)
-                        ARMIEvent.createProxy(
-                                game_router_handler,
-                                new GameArgumentWriter(distributable_table),
-                                PlayerInterface.class);
+        if (is_spectator) {
+            this.player_interface = new NoOpPlayerInterface();
+        } else {
+            this.player_interface =
+                    (PlayerInterface)
+                            ARMIEvent.createProxy(
+                                    game_router_handler,
+                                    new GameArgumentWriter(distributable_table),
+                                    PlayerInterface.class);
+        }
         ARMIEventWriter hub_router_handler =
                 new ARMIEventWriter() {
                     public final void handle(ARMIEvent event) {
@@ -181,10 +188,12 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
                 (PeerHubInterface)
                         ARMIEvent.createProxy(hub_router_handler, PeerHubInterface.class);
         manager.registerAnimation(this);
-        router_client.connect(
-                session_id,
-                new SessionInfo(num_participants, MILLISECONDS_PER_HEARTBEAT),
-                local_peer_index);
+        if (!is_spectator) {
+            router_client.connect(
+                    session_id,
+                    new SessionInfo(num_participants, MILLISECONDS_PER_HEARTBEAT),
+                    local_peer_index);
+        }
     }
 
     public final void routerFailed(Exception e) {
@@ -240,7 +249,7 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
         server_millis = millis;
         int event_tick = millisToTickCeil(millis);
         peer.addEvent(event_tick, event);
-        if (local_peer_index == 0 && Network.getMatchmakingClient().isConnected()) {
+        if (!is_spectator && local_peer_index == 0 && Network.getMatchmakingClient().isConnected()) {
             sendCommandEvent(event_tick, client_id, event);
         }
     }
@@ -336,27 +345,29 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
 
     private final void doTick(float t) {
         stall_handler.stopStall();
-        if (getFreeQuitTicksLeft(local_player.getWorld()) == 0
-                && Network.getMatchmakingClient().isConnected())
-            Network.getMatchmakingClient().getInterface().freeQuitStopNotify();
+        if (!is_spectator) {
+            if (getFreeQuitTicksLeft(local_player.getWorld()) == 0
+                    && Network.getMatchmakingClient().isConnected())
+                Network.getMatchmakingClient().getInterface().freeQuitStopNotify();
 
-        if (getTick() % TICKS_PER_STATUS_UPDATE == 0
-                && Network.getMatchmakingClient().isConnected()) sendStatusUpdate();
+            if (getTick() % TICKS_PER_STATUS_UPDATE == 0
+                    && Network.getMatchmakingClient().isConnected()) sendStatusUpdate();
 
-        if (!sent_map) {
-            sendMap();
+            if (!sent_map) {
+                sendMap();
+            }
+
+            if (!sent_init_info) {
+                sendInitInfo();
+            }
+
+            if (!sent_trees) {
+                sendTrees();
+            }
+
+            if (getTick() % TICKS_PER_SPECTATOR_UPDATE == 0
+                    && Network.getMatchmakingClient().isConnected()) sendSpectatorInfo();
         }
-
-        if (!sent_init_info) {
-            sendInitInfo();
-        }
-
-        if (!sent_trees) {
-            sendTrees();
-        }
-
-        if (getTick() % TICKS_PER_SPECTATOR_UPDATE == 0
-                && Network.getMatchmakingClient().isConnected()) sendSpectatorInfo();
 
         for (int i = 0; i < peer_index_to_peer.length; i++) {
             Peer peer = peer_index_to_peer[i];
@@ -370,7 +381,7 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
             }
         }
         local_player.getWorld().tick(t);
-        if (getTick() % TICKS_PER_CHECKSUM == 0) sendChecksum();
+        if (!is_spectator && getTick() % TICKS_PER_CHECKSUM == 0) sendChecksum();
     }
 
     private void sendChecksum() {

--- a/tt/classes/com/oddlabs/tt/net/PeerHub.java
+++ b/tt/classes/com/oddlabs/tt/net/PeerHub.java
@@ -26,6 +26,7 @@ import com.oddlabs.tt.util.Utils;
 import com.oddlabs.tt.viewer.NotificationManager;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -71,6 +72,7 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
     private final boolean is_multiplayer;
     private final boolean is_rated;
     private final StallHandler stall_handler;
+    private int local_peer_index;
 
     private int pause_ticks;
     private int server_millis;
@@ -109,7 +111,7 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
         GameArgumentReader argument_reader = new GameArgumentReader(distributable_table);
         List peer_index_to_peer_list = new ArrayList();
         Player[] players = local_player.getWorld().getPlayers();
-        int local_peer_index = -1;
+        this.local_peer_index = -1;
         if (!is_multiplayer) {
             this.router =
                     new Router(
@@ -148,7 +150,7 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
             Peer peer = new Peer(this, peer_index, player, argument_reader, peer_interface);
             ARMIEventWriter peer_broker;
             if (player == local_player) {
-                local_peer_index = peer_index;
+                this.local_peer_index = peer_index;
             }
             peer_index_to_peer_list.add(peer);
             peer_to_player.put(peer, player);
@@ -236,7 +238,21 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
             return;
         }
         server_millis = millis;
-        peer.addEvent(millisToTickCeil(millis), event);
+        int event_tick = millisToTickCeil(millis);
+        peer.addEvent(event_tick, event);
+        if (local_peer_index == 0 && Network.getMatchmakingClient().isConnected()) {
+            sendCommandEvent(event_tick, client_id, event);
+        }
+    }
+
+    private final void sendCommandEvent(int tick, int client_id, ARMIEvent event) {
+        short event_size = event.getEventSize();
+        ByteBuffer buf = ByteBuffer.allocate(event_size);
+        event.write(buf);
+        byte[] event_data = buf.array();
+        Network.getMatchmakingClient()
+                .getInterface()
+                .updateCommandEvent(tick, client_id, event_size, event_data);
     }
 
     public final void playerDisconnected(int client_id, boolean checksum_error) {

--- a/tt/classes/com/oddlabs/tt/net/PeerHub.java
+++ b/tt/classes/com/oddlabs/tt/net/PeerHub.java
@@ -25,6 +25,8 @@ import com.oddlabs.tt.util.StateChecksum;
 import com.oddlabs.tt.util.Utils;
 import com.oddlabs.tt.viewer.NotificationManager;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -49,6 +51,7 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
     private static final int TICKS_PER_SPECTATOR_UPDATE = 5;
     private static final int TICKS_PER_CHECKSUM =
             (int) (10 / AnimationManager.ANIMATION_SECONDS_PER_TICK);
+    private static final int CATCH_UP_TICKS_PER_FRAME = 15;
 
     private static boolean waiting_for_ack = false;
 
@@ -83,6 +86,8 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
     private boolean sent_init_info = false;
     private boolean sent_trees = false;
     private int rows_sent = 0;
+    private boolean catching_up = false;
+    private int catch_up_target_tick = 0;
 
     static {
         SYSTEM_NAME = Utils.getBundleString(bundle, "system_name");
@@ -323,6 +328,19 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
 
     public final void animate(float t) {
         if (router != null) router.process();
+        if (is_spectator && catching_up) {
+            int ticks_this_frame = 0;
+            while (getTick() < catch_up_target_tick && ticks_this_frame < CATCH_UP_TICKS_PER_FRAME) {
+                doTick(t);
+                ticks_this_frame++;
+            }
+            if (getTick() >= catch_up_target_tick) {
+                catching_up = false;
+                System.out.println("Spectator catch-up complete at tick " + getTick());
+            }
+            return;
+        }
+        if (is_spectator && !is_synchronized) return;
         int server_tick = millisToTick(server_millis);
         if (!is_synchronized || getTick() == server_tick) {
             processStall();
@@ -601,6 +619,37 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
         closeNetwork();
         LocalEventQueue.getQueue().getManager().removeAnimation(this);
         System.out.println("PeerHub closed");
+    }
+
+    public final void fastForward(byte[] event_log_data, int target_tick) {
+        // Deserialize events and queue them on peers
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(event_log_data));
+        int event_count = 0;
+        try {
+            while (dis.available() > 0) {
+                int tick = dis.readInt();
+                int client_id = dis.readInt();
+                short event_size = dis.readShort();
+                byte[] event_data = new byte[event_size];
+                dis.readFully(event_data);
+
+                ByteBuffer buf = ByteBuffer.wrap(event_data);
+                ARMIEvent event = ARMIEvent.read(buf, event_size);
+
+                Peer peer = getPeerFromClientID(client_id);
+                if (peer != null) {
+                    peer.addEvent(tick, event);
+                    event_count++;
+                }
+            }
+        } catch (IOException e) {
+            System.out.println("Error reading event log: " + e);
+        }
+
+        // Set up catch-up to run via animate() — ticks per frame with rendering between
+        this.catch_up_target_tick = target_tick;
+        this.catching_up = true;
+        System.out.println("Spectator catching up to tick " + target_tick + " (" + event_count + " events queued)");
     }
 
     private static int getFreeQuitTicksLeft(World world) {

--- a/tt/classes/com/oddlabs/tt/net/PeerHub.java
+++ b/tt/classes/com/oddlabs/tt/net/PeerHub.java
@@ -78,6 +78,8 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
     private final StallHandler stall_handler;
     private int local_peer_index;
 
+    private static PeerHub spectator_instance;
+
     private int pause_ticks;
     private int server_millis;
     private int paused;
@@ -194,6 +196,7 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
                         ARMIEvent.createProxy(hub_router_handler, PeerHubInterface.class);
         manager.registerAnimation(this);
         if (is_spectator) {
+            spectator_instance = this;
             router_client.connectSpectator(session_id);
         } else {
             router_client.connect(
@@ -303,7 +306,21 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
     }
 
     public final void start() {
-        is_synchronized = true;
+        if (is_spectator) {
+            // Don't set is_synchronized yet. For a spectator we need to wait for the event log
+            // and complete fast-forward before allowing heartbeat-driven ticking.
+            // Otherwise animate() will run empty ticks (no events queued) while
+            // we wait for the event log, corrupting the simulation state.
+            if (Network.getMatchmakingClient().isConnected()) {
+                Network.getMatchmakingClient().getInterface().requestSpectatorEventLog();
+            }
+        } else {
+            is_synchronized = true;
+        }
+    }
+
+    public static PeerHub getSpectatorInstance() {
+        return spectator_instance;
     }
 
     private final Peer locatePeerFromPlayer(Player player) {
@@ -346,7 +363,9 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
             }
             if (getTick() >= catch_up_target_tick) {
                 catching_up = false;
-                System.out.println("Spectator catch-up complete at tick " + getTick());
+                is_synchronized = true;
+                System.out.println("Spectator catch-up complete at tick " + getTick()
+                        + ", server_millis=" + server_millis + ", now synchronized");
             }
             return;
         }
@@ -627,6 +646,9 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
     public final void close() {
         closeNetwork();
         LocalEventQueue.getQueue().getManager().removeAnimation(this);
+        if (spectator_instance == this) {
+            spectator_instance = null;
+        }
         System.out.println("PeerHub closed");
     }
 

--- a/tt/classes/com/oddlabs/tt/net/PeerHub.java
+++ b/tt/classes/com/oddlabs/tt/net/PeerHub.java
@@ -639,6 +639,10 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
                 int tick = dis.readInt();
                 int client_id = dis.readInt();
                 short event_size = dis.readShort();
+                if (event_size <= 0 || event_size > dis.available()) {
+                    System.out.println("Invalid event_size in event log: " + event_size);
+                    break;
+                }
                 byte[] event_data = new byte[event_size];
                 dis.readFully(event_data);
 

--- a/tt/classes/com/oddlabs/tt/net/PeerHub.java
+++ b/tt/classes/com/oddlabs/tt/net/PeerHub.java
@@ -256,9 +256,7 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
         server_millis = millis;
         int event_tick = millisToTickCeil(millis);
         peer.addEvent(event_tick, event);
-        if (!is_spectator
-                && local_peer_index == 0
-                && Network.getMatchmakingClient().isConnected()) {
+        if (!is_spectator && isFirstActivePeer() && Network.getMatchmakingClient().isConnected()) {
             sendCommandEvent(event_tick, client_id, event);
         }
     }
@@ -285,6 +283,13 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
                         + peer.getPlayerInfo().getName());
         peerDisconnected(peer, "Checksum error");
         Globals.checksum_error_in_last_game = true;
+    }
+
+    private boolean isFirstActivePeer() {
+        for (int i = 0; i < peer_index_to_peer.length; i++) {
+            if (peer_index_to_peer[i] != null) return i == local_peer_index;
+        }
+        return false;
     }
 
     private Peer getPeerFromClientID(int client_id) {

--- a/tt/classes/com/oddlabs/tt/net/PeerHub.java
+++ b/tt/classes/com/oddlabs/tt/net/PeerHub.java
@@ -193,7 +193,9 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
                 (PeerHubInterface)
                         ARMIEvent.createProxy(hub_router_handler, PeerHubInterface.class);
         manager.registerAnimation(this);
-        if (!is_spectator) {
+        if (is_spectator) {
+            router_client.connectSpectator(session_id);
+        } else {
             router_client.connect(
                     session_id,
                     new SessionInfo(num_participants, MILLISECONDS_PER_HEARTBEAT),
@@ -340,7 +342,6 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
             }
             return;
         }
-        if (is_spectator && !is_synchronized) return;
         int server_tick = millisToTick(server_millis);
         if (!is_synchronized || getTick() == server_tick) {
             processStall();

--- a/tt/classes/com/oddlabs/tt/net/PeerHub.java
+++ b/tt/classes/com/oddlabs/tt/net/PeerHub.java
@@ -364,8 +364,12 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
             if (getTick() >= catch_up_target_tick) {
                 catching_up = false;
                 is_synchronized = true;
-                System.out.println("Spectator catch-up complete at tick " + getTick()
-                        + ", server_millis=" + server_millis + ", now synchronized");
+                System.out.println(
+                        "Spectator catch-up complete at tick "
+                                + getTick()
+                                + ", server_millis="
+                                + server_millis
+                                + ", now synchronized");
             }
             return;
         }

--- a/tt/classes/com/oddlabs/tt/net/PeerHub.java
+++ b/tt/classes/com/oddlabs/tt/net/PeerHub.java
@@ -256,7 +256,9 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
         server_millis = millis;
         int event_tick = millisToTickCeil(millis);
         peer.addEvent(event_tick, event);
-        if (!is_spectator && local_peer_index == 0 && Network.getMatchmakingClient().isConnected()) {
+        if (!is_spectator
+                && local_peer_index == 0
+                && Network.getMatchmakingClient().isConnected()) {
             sendCommandEvent(event_tick, client_id, event);
         }
     }
@@ -332,7 +334,8 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
         if (router != null) router.process();
         if (is_spectator && catching_up) {
             int ticks_this_frame = 0;
-            while (getTick() < catch_up_target_tick && ticks_this_frame < CATCH_UP_TICKS_PER_FRAME) {
+            while (getTick() < catch_up_target_tick
+                    && ticks_this_frame < CATCH_UP_TICKS_PER_FRAME) {
                 doTick(t);
                 ticks_this_frame++;
             }
@@ -650,7 +653,12 @@ public final strictfp class PeerHub implements Animated, RouterHandler {
         // Set up catch-up to run via animate() — ticks per frame with rendering between
         this.catch_up_target_tick = target_tick;
         this.catching_up = true;
-        System.out.println("Spectator catching up to tick " + target_tick + " (" + event_count + " events queued)");
+        System.out.println(
+                "Spectator catching up to tick "
+                        + target_tick
+                        + " ("
+                        + event_count
+                        + " events queued)");
     }
 
     private static int getFreeQuitTicksLeft(World world) {

--- a/tt/classes/com/oddlabs/tt/net/ReplayWorldStarter.java
+++ b/tt/classes/com/oddlabs/tt/net/ReplayWorldStarter.java
@@ -1,0 +1,97 @@
+package com.oddlabs.tt.net;
+
+import com.oddlabs.net.NetworkSelector;
+import com.oddlabs.router.SessionID;
+import com.oddlabs.tt.animation.AnimationManager;
+import com.oddlabs.tt.form.LoadCallback;
+import com.oddlabs.tt.gui.GUIRoot;
+import com.oddlabs.tt.landscape.WorldParameters;
+import com.oddlabs.tt.player.Player;
+import com.oddlabs.tt.player.UnitInfo;
+import com.oddlabs.tt.render.UIRenderer;
+import com.oddlabs.tt.resource.WorldGenerator;
+import com.oddlabs.tt.viewer.InGameInfo;
+import com.oddlabs.tt.viewer.WorldViewer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final strictfp class ReplayWorldStarter implements LoadCallback {
+    private final UnitInfo[] unit_infos;
+    private final PlayerSlot[] player_slots;
+    private final short player_slot;
+    private final InGameInfo ingame_info;
+    private final NetworkSelector network;
+    private final WorldGenerator generator;
+    private final WorldParameters world_params;
+    private final WorldInitAction initial_action;
+    private final int session_id;
+    private final byte[] event_log_data;
+    private final int target_tick;
+
+    ReplayWorldStarter(
+            NetworkSelector network,
+            int session_id,
+            WorldGenerator generator,
+            WorldParameters world_params,
+            PlayerSlot[] player_slots,
+            UnitInfo[] unit_infos,
+            short player_slot,
+            InGameInfo ingame_info,
+            WorldInitAction initial_action,
+            byte[] event_log_data,
+            int target_tick) {
+        this.initial_action = initial_action;
+        this.session_id = session_id;
+        this.world_params = world_params;
+        this.generator = generator;
+        this.unit_infos = unit_infos;
+        this.player_slots = player_slots;
+        this.player_slot = player_slot;
+        this.ingame_info = ingame_info;
+        this.network = network;
+        this.event_log_data = event_log_data;
+        this.target_tick = target_tick;
+    }
+
+    public final UIRenderer load(GUIRoot gui_root) {
+        AnimationManager.freezeTime();
+        List player_slot_list = new ArrayList();
+        List unit_info_list = new ArrayList();
+        List color_list = new ArrayList();
+        short corrected_player_slot = -1;
+        for (short i = 0; i < player_slots.length; i++) {
+            if (player_slots[i].getInfo() != null) {
+                if (player_slot == i) corrected_player_slot = (short) player_slot_list.size();
+                player_slot_list.add(player_slots[i]);
+                unit_info_list.add(unit_infos[i]);
+                color_list.add(Player.COLORS[i]);
+            }
+        }
+        assert corrected_player_slot != -1;
+        PlayerSlot[] player_slots = (PlayerSlot[]) player_slot_list.toArray(new PlayerSlot[0]);
+        UnitInfo[] corrected_unit_infos = (UnitInfo[]) unit_info_list.toArray(new UnitInfo[0]);
+        float[][] corrected_colors = (float[][]) color_list.toArray(new float[0][]);
+        WorldViewer viewer =
+                new WorldViewer(
+                        network,
+                        gui_root,
+                        world_params,
+                        ingame_info,
+                        generator,
+                        player_slots,
+                        corrected_unit_infos,
+                        corrected_colors,
+                        corrected_player_slot,
+                        new SessionID(session_id));
+        if (initial_action != null) initial_action.run(viewer);
+
+        // Fast-forward the simulation to catch up
+        if (event_log_data != null && event_log_data.length > 0 && target_tick > 0) {
+            viewer.getPeerHub().fastForward(event_log_data, target_tick);
+        }
+
+        System.out.println("ReplayWorldStarter complete (session_id = " + session_id + ")");
+        return viewer.getRenderer();
+    }
+}

--- a/tt/classes/com/oddlabs/tt/net/ReplayWorldStarter.java
+++ b/tt/classes/com/oddlabs/tt/net/ReplayWorldStarter.java
@@ -26,8 +26,6 @@ final strictfp class ReplayWorldStarter implements LoadCallback {
     private final WorldParameters world_params;
     private final WorldInitAction initial_action;
     private final int session_id;
-    private final byte[] event_log_data;
-    private final int target_tick;
 
     ReplayWorldStarter(
             NetworkSelector network,
@@ -38,9 +36,7 @@ final strictfp class ReplayWorldStarter implements LoadCallback {
             UnitInfo[] unit_infos,
             short player_slot,
             InGameInfo ingame_info,
-            WorldInitAction initial_action,
-            byte[] event_log_data,
-            int target_tick) {
+            WorldInitAction initial_action) {
         this.initial_action = initial_action;
         this.session_id = session_id;
         this.world_params = world_params;
@@ -50,8 +46,6 @@ final strictfp class ReplayWorldStarter implements LoadCallback {
         this.player_slot = player_slot;
         this.ingame_info = ingame_info;
         this.network = network;
-        this.event_log_data = event_log_data;
-        this.target_tick = target_tick;
     }
 
     public final UIRenderer load(GUIRoot gui_root) {
@@ -85,11 +79,6 @@ final strictfp class ReplayWorldStarter implements LoadCallback {
                         corrected_player_slot,
                         new SessionID(session_id));
         if (initial_action != null) initial_action.run(viewer);
-
-        // Fast-forward the simulation to catch up
-        if (event_log_data != null && event_log_data.length > 0 && target_tick > 0) {
-            viewer.getPeerHub().fastForward(event_log_data, target_tick);
-        }
 
         System.out.println("ReplayWorldStarter complete (session_id = " + session_id + ")");
         return viewer.getRenderer();

--- a/tt/classes/com/oddlabs/tt/net/RouterClient.java
+++ b/tt/classes/com/oddlabs/tt/net/RouterClient.java
@@ -36,6 +36,12 @@ public final strictfp class RouterClient implements ConnectionInterface {
         router_interface.login(session_id, session_info, client_id);
     }
 
+    public final void connectSpectator(SessionID session_id) {
+        RouterInterface router_interface =
+                (RouterInterface) ARMIEvent.createProxy(connection, RouterInterface.class);
+        router_interface.loginSpectator(session_id);
+    }
+
     public final GameInterface getInterface() {
         return game_interface;
     }

--- a/tt/classes/com/oddlabs/tt/net/SpectatorWorldInitAction.java
+++ b/tt/classes/com/oddlabs/tt/net/SpectatorWorldInitAction.java
@@ -1,0 +1,11 @@
+package com.oddlabs.tt.net;
+
+import com.oddlabs.tt.delegate.Menu;
+import com.oddlabs.tt.viewer.WorldViewer;
+
+public final strictfp class SpectatorWorldInitAction implements WorldInitAction {
+    public void run(WorldViewer viewer) {
+        Menu.completeGameSetupHack(viewer);
+        viewer.getDelegate().setObserverMode();
+    }
+}

--- a/tt/classes/com/oddlabs/tt/net/WorldStarter.java
+++ b/tt/classes/com/oddlabs/tt/net/WorldStarter.java
@@ -14,6 +14,7 @@ import com.oddlabs.tt.player.UnitInfo;
 import com.oddlabs.tt.render.UIRenderer;
 import com.oddlabs.tt.resource.WorldGenerator;
 import com.oddlabs.tt.viewer.InGameInfo;
+import com.oddlabs.tt.viewer.SpectatorInGameInfo;
 import com.oddlabs.tt.viewer.WorldViewer;
 
 import java.io.ByteArrayOutputStream;
@@ -119,7 +120,8 @@ final strictfp class WorldStarter implements LoadCallback {
         }
         Participant[] participants = new Participant[participant_list.size()];
         participant_list.toArray(participants);
-        if (Network.getMatchmakingClient().isConnected()) {
+        if (Network.getMatchmakingClient().isConnected()
+                && !(ingame_info instanceof SpectatorInGameInfo)) {
             GameSession game_session =
                     new GameSession(session_id, participants, ingame_info.isRated(), gamePlayers);
             Network.getMatchmakingClient().getInterface().gameStartedNotify(game_session);

--- a/tt/classes/com/oddlabs/tt/net/WorldStarter.java
+++ b/tt/classes/com/oddlabs/tt/net/WorldStarter.java
@@ -139,6 +139,7 @@ final strictfp class WorldStarter implements LoadCallback {
             oos.writeObject(world_params);
             oos.writeObject(player_slots);
             oos.writeObject(unit_infos);
+            oos.writeFloat(ingame_info.getRandomStartPosition());
             oos.close();
             Network.getMatchmakingClient()
                     .getInterface()

--- a/tt/classes/com/oddlabs/tt/net/WorldStarter.java
+++ b/tt/classes/com/oddlabs/tt/net/WorldStarter.java
@@ -140,6 +140,7 @@ final strictfp class WorldStarter implements LoadCallback {
             oos.writeObject(player_slots);
             oos.writeObject(unit_infos);
             oos.writeFloat(ingame_info.getRandomStartPosition());
+            oos.writeInt(session_id);
             oos.close();
             Network.getMatchmakingClient()
                     .getInterface()

--- a/tt/classes/com/oddlabs/tt/net/WorldStarter.java
+++ b/tt/classes/com/oddlabs/tt/net/WorldStarter.java
@@ -142,9 +142,7 @@ final strictfp class WorldStarter implements LoadCallback {
             oos.writeFloat(ingame_info.getRandomStartPosition());
             oos.writeInt(session_id);
             oos.close();
-            Network.getMatchmakingClient()
-                    .getInterface()
-                    .updateWorldParams(baos.toByteArray());
+            Network.getMatchmakingClient().getInterface().updateWorldParams(baos.toByteArray());
         } catch (Exception e) {
             System.out.println("Exception serializing world params: " + e);
         }

--- a/tt/classes/com/oddlabs/tt/net/WorldStarter.java
+++ b/tt/classes/com/oddlabs/tt/net/WorldStarter.java
@@ -16,6 +16,8 @@ import com.oddlabs.tt.resource.WorldGenerator;
 import com.oddlabs.tt.viewer.InGameInfo;
 import com.oddlabs.tt.viewer.WorldViewer;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -121,8 +123,26 @@ final strictfp class WorldStarter implements LoadCallback {
             GameSession game_session =
                     new GameSession(session_id, participants, ingame_info.isRated(), gamePlayers);
             Network.getMatchmakingClient().getInterface().gameStartedNotify(game_session);
+            sendWorldParams(player_slots, corrected_unit_infos);
         }
         System.out.println("PeerHub created (session_id = " + session_id + ") Player list:");
         return viewer.getRenderer();
+    }
+
+    private void sendWorldParams(PlayerSlot[] player_slots, UnitInfo[] unit_infos) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(generator);
+            oos.writeObject(world_params);
+            oos.writeObject(player_slots);
+            oos.writeObject(unit_infos);
+            oos.close();
+            Network.getMatchmakingClient()
+                    .getInterface()
+                    .updateWorldParams(baos.toByteArray());
+        } catch (Exception e) {
+            System.out.println("Exception serializing world params: " + e);
+        }
     }
 }

--- a/tt/classes/com/oddlabs/tt/player/UnitInfo.java
+++ b/tt/classes/com/oddlabs/tt/player/UnitInfo.java
@@ -1,6 +1,9 @@
 package com.oddlabs.tt.player;
 
-public final strictfp class UnitInfo {
+import java.io.Serializable;
+
+public final strictfp class UnitInfo implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final boolean has_quarters;
     private final boolean has_armory;
     private final int num_towers;

--- a/tt/classes/com/oddlabs/tt/viewer/SpectatorInGameInfo.java
+++ b/tt/classes/com/oddlabs/tt/viewer/SpectatorInGameInfo.java
@@ -1,0 +1,28 @@
+package com.oddlabs.tt.viewer;
+
+import com.oddlabs.tt.delegate.GameStatsDelegate;
+import com.oddlabs.tt.delegate.InGameMainMenu;
+import com.oddlabs.tt.gui.Group;
+
+public final strictfp class SpectatorInGameInfo implements InGameInfo {
+    public void addGUI(WorldViewer viewer, InGameMainMenu menu, Group game_infos) {}
+
+    public void addGameOverGUI(
+            WorldViewer viewer, GameStatsDelegate delegate, int header_y, Group buttons) {}
+
+    public void abort(WorldViewer viewer) {}
+
+    public void close(WorldViewer viewer) {}
+
+    public boolean isMultiplayer() {
+        return true;
+    }
+
+    public boolean isRated() {
+        return false;
+    }
+
+    public float getRandomStartPosition() {
+        return 0f;
+    }
+}

--- a/tt/classes/com/oddlabs/tt/viewer/SpectatorInGameInfo.java
+++ b/tt/classes/com/oddlabs/tt/viewer/SpectatorInGameInfo.java
@@ -1,28 +1,17 @@
 package com.oddlabs.tt.viewer;
 
-import com.oddlabs.tt.delegate.GameStatsDelegate;
-import com.oddlabs.tt.delegate.InGameMainMenu;
-import com.oddlabs.tt.gui.Group;
+public final strictfp class SpectatorInGameInfo extends DefaultInGameInfo {
+    private final float random_start_position;
 
-public final strictfp class SpectatorInGameInfo implements InGameInfo {
-    public void addGUI(WorldViewer viewer, InGameMainMenu menu, Group game_infos) {}
-
-    public void addGameOverGUI(
-            WorldViewer viewer, GameStatsDelegate delegate, int header_y, Group buttons) {}
-
-    public void abort(WorldViewer viewer) {}
-
-    public void close(WorldViewer viewer) {}
+    public SpectatorInGameInfo(float random_start_position) {
+        this.random_start_position = random_start_position;
+    }
 
     public boolean isMultiplayer() {
         return true;
     }
 
-    public boolean isRated() {
-        return false;
-    }
-
     public float getRandomStartPosition() {
-        return 0f;
+        return random_start_position;
     }
 }

--- a/tt/classes/com/oddlabs/tt/viewer/WorldViewer.java
+++ b/tt/classes/com/oddlabs/tt/viewer/WorldViewer.java
@@ -221,7 +221,8 @@ public final strictfp class WorldViewer implements Animated {
                         notification_manager,
                         distributable_table,
                         session_id,
-                        new ViewerStallHandler(this));
+                        new ViewerStallHandler(this),
+                        ingame_info instanceof SpectatorInGameInfo);
         this.camera = new GameCamera(this, camera_state);
         this.panel = new ActionButtonPanel(this, camera);
         this.delegate = new SelectionDelegate(this, camera);

--- a/tt/i18n/com/oddlabs/tt/form/ChatErrorForm.properties
+++ b/tt/i18n/com/oddlabs/tt/form/ChatErrorForm.properties
@@ -1,3 +1,4 @@
 chat_error_too_many_users=ERROR: Unable to join room. Too many users.
 chat_error_invalid_name=ERROR: Unable to join room. Invalid name.
 chat_error_no_such_nick=ERROR: No such nick.
+chat_error_spectate_failed=ERROR: Failed to load spectator data.

--- a/tt/i18n/com/oddlabs/tt/gui/ChatPanel.properties
+++ b/tt/i18n/com/oddlabs/tt/gui/ChatPanel.properties
@@ -10,3 +10,4 @@ send=Send
 leave=Leave
 unignore=Unignore
 ignore=Ignore
+spectate=Spectate


### PR DESCRIPTION
# Spectator Mode

Allows players to spectate live games. Right-click a player in the "Playing" list and select Spectate. Implemented #19. PR may be easier to review if you follow commit by commit vs looking at the entire diff since I tried to phase the changes into several logical commits rather than a single large commit.

## Event streaming

- First active peer serializes player commands each tick and streams them to the matchmaking server via `updateCommandEvent`
- If the streaming peer disconnects, the next active peer automatically takes over — no reliance on a specific player
- Host sends world params, map data, tree positions, and player info so the server has everything needed to reconstruct the world
- Matchmaking server accumulates an event log and serves it to spectators on request

## Spectator world setup

- `ReplayWorldStarter` creates the world from the serialized world params
- `SpectatorWorldInitAction` initializes the spectator's view
- `NoOpPlayerInterface` prevents the spectator from issuing commands
- `PeerHub.fastForward()` replays the event log at ~15 ticks/frame to catch up (might need to be adjusted)

## Router integration & live transition

- Spectator connects to the Router immediately as a read-only peer via new `loginSpectator`
- Router tracks spectators separately. They receive heartbeats and game events but never send checksums or relay commands
- Sessions remain in the lookup map while running so spectators can find them; guarded against normal players re-joining started sessions
- After catch-up completes, heartbeats seamlessly drive the simulation forward — no gap in events
- Spectators are kicked when all players leave (to ensure sessions do not linger)

## Chat panel

- Split lobby/playing right-click menus into separate listeners
- Playing menu: Message, Info, Spectate, Ignore
- Lobby menu: Message, Info, Ignore
