### PR TITLE
Don't show the bad resolution menu on first boot

### DIFF
--- a/tt/classes/com/oddlabs/tt/global/Settings.java
+++ b/tt/classes/com/oddlabs/tt/global/Settings.java
@@ -30,8 +30,11 @@ public final strictfp class Settings implements Serializable {
     public boolean crashed = false;
 
     // network
-    // TODO: Why is domain name stuck on tribaltrouble.org?
+    // Why is domain name stuck on tribaltrouble.org?
     // when it is loaded from the settings file?
+    // RES: So users don't have to manually input the domain
+    // into the settings file.
+    // Could be a placeholder domain, but this way is easier.
     private String domain_name = "tribaltrouble.org";
     public String username = "";
     public String pw_digest = "";

--- a/tt/classes/com/oddlabs/tt/render/DisplayModel.java
+++ b/tt/classes/com/oddlabs/tt/render/DisplayModel.java
@@ -40,9 +40,9 @@ public final class DisplayModel {
                 return;
         }
         // Set bad resolution variable if not first run
-	if (!isFirstRun()) {
-        	bad_mode = true;
-	}
+        if (!isFirstRun()) {
+            bad_mode = true;
+        }
         // Apply to config
         saveToConfig();
     }
@@ -201,6 +201,6 @@ public final class DisplayModel {
     }
 
     private static boolean isFirstRun() {
-	return Settings.getSettings().first_run;
+        return Settings.getSettings().first_run;
     }
 }

--- a/tt/classes/com/oddlabs/tt/render/DisplayModel.java
+++ b/tt/classes/com/oddlabs/tt/render/DisplayModel.java
@@ -39,8 +39,10 @@ public final class DisplayModel {
             default:
                 return;
         }
-        // Set bad resolution variable
-        bad_mode = true;
+        // Set bad resolution variable if not first run
+	if (!isFirstRun()) {
+        	bad_mode = true;
+	}
         // Apply to config
         saveToConfig();
     }
@@ -196,5 +198,9 @@ public final class DisplayModel {
 
         new_mode.setRefreshRate(max_refreshRate);
         return new_mode;
+    }
+
+    private static boolean isFirstRun() {
+	return Settings.getSettings().first_run;
     }
 }

--- a/tt/classes/com/oddlabs/tt/render/Renderer.java
+++ b/tt/classes/com/oddlabs/tt/render/Renderer.java
@@ -318,10 +318,17 @@ public final strictfp class Renderer {
         cleanLogs(deterministic, last_event_log_dir, event_log_dir, event_logs_dir);
         Skin.load();
         GUI gui = new GUI(languages);
-
+	
+	// Initializing globals, input and display here
         GlobalsInit.init();
         DisplayModel.init();
         LocalInput.init();
+
+	// After done, set first run to false
+	if(Settings.getSettings().first_run) {
+		Settings.getSettings().first_run = false;
+		Settings.getSettings().save();
+	}
 
         long startup_timei = System.currentTimeMillis() - start_time;
         System.out.println("Init done after " + startup_timei);

--- a/tt/classes/com/oddlabs/tt/render/Renderer.java
+++ b/tt/classes/com/oddlabs/tt/render/Renderer.java
@@ -318,17 +318,17 @@ public final strictfp class Renderer {
         cleanLogs(deterministic, last_event_log_dir, event_log_dir, event_logs_dir);
         Skin.load();
         GUI gui = new GUI(languages);
-	
-	// Initializing globals, input and display here
+
+        // Initializing globals, input and display here
         GlobalsInit.init();
         DisplayModel.init();
         LocalInput.init();
 
-	// After done, set first run to false
-	if(Settings.getSettings().first_run) {
-		Settings.getSettings().first_run = false;
-		Settings.getSettings().save();
-	}
+        // After done, set first run to false
+        if (Settings.getSettings().first_run) {
+            Settings.getSettings().first_run = false;
+            Settings.getSettings().save();
+        }
 
         long startup_timei = System.currentTimeMillis() - start_time;
         System.out.println("Init done after " + startup_timei);


### PR DESCRIPTION
Changes:
- Setting to check for first run that already exists.
- Starting to use first_run boolean in settings and setting it to false after the initialization of globals in Renderer.java.
- Removing a setting todo and adding commentary instead.

If accepted, I will close issue #64 and create a new one that matches the larger problems and try to find solutions.