### PR TITLE
Enhance menu behavior and scrolling for lobby dropdowns

### DIFF
--- a/tt/src/main/java/com/oddlabs/tt/form/GameMenu.java
+++ b/tt/src/main/java/com/oddlabs/tt/form/GameMenu.java
@@ -278,13 +278,13 @@ public final class GameMenu extends Panel implements ConfigurationListener, Chat
             PulldownButton<?> team_button = team_buttons[i];
             Diode ready_mark = ready_marks[i];
             ready_mark.setLit(player.isReady());
-            race_button.getMenu().chooseItem(player.getInfo() != null ? player.getInfo().getRace() : 0);
-            team_button.getMenu().chooseItem(player.getInfo() != null ? player.getInfo().getTeam() : 0);
+            race_button.setSelected(player.getInfo() != null ? player.getInfo().getRace() : 0);
+            team_button.setSelected(player.getInfo() != null ? player.getInfo().getTeam() : 0);
             if (player.getType() != PlayerSlot.CLOSED) {
                 slot_button.getMenu().getItem(OPEN_INDEX).setLabelString(i18n("open"));
-                slot_button.getMenu().chooseItem(OPEN_INDEX);
+                slot_button.setSelected(OPEN_INDEX);
             } else {
-                slot_button.getMenu().chooseItem(CLOSED_INDEX);
+                slot_button.setSelected(CLOSED_INDEX);
             }
             race_button.setDisabled(true);
             team_button.setDisabled(true);
@@ -293,7 +293,7 @@ public final class GameMenu extends Panel implements ConfigurationListener, Chat
                 switch (player.getType()) {
                     case PlayerSlot.AI:
                         assert !rated;
-                        slot_button.getMenu().chooseItem(player.getAIDifficulty() + 1);
+                        slot_button.setSelected(player.getAIDifficulty() + 1);
                         race_button.setDisabled(!canControlSlot(i));
                         team_button.setDisabled(!canControlSlot(i));
                         break;
@@ -301,7 +301,7 @@ public final class GameMenu extends Panel implements ConfigurationListener, Chat
                         String player_name = player_info.getName();
                         new_human_names.add(player_name);
                         slot_button.getMenu().getItem(OPEN_INDEX).setLabelString(player_name);
-                        slot_button.getMenu().chooseItem(OPEN_INDEX);
+                        slot_button.setSelected(OPEN_INDEX);
                         race_button.setDisabled(i != local_player_slot);
                         team_button.setDisabled(i != local_player_slot);
                         player_slots[human_index] = i;

--- a/tt/src/main/java/com/oddlabs/tt/gui/ArrowButton.java
+++ b/tt/src/main/java/com/oddlabs/tt/gui/ArrowButton.java
@@ -30,8 +30,8 @@ public final class ArrowButton extends ButtonObject {
             return;
         }
 
-        if (event.hasAction(GameAction.UI_FOCUS_NEXT)) {
-            // Bubble TAB
+        if (event.hasAction(GameAction.UI_FOCUS_NEXT) || event.hasAction(GameAction.UI_CANCEL)) {
+            // Bubble TAB and Escape
             return;
         }
 

--- a/tt/src/main/java/com/oddlabs/tt/gui/GUIObject.java
+++ b/tt/src/main/java/com/oddlabs/tt/gui/GUIObject.java
@@ -508,8 +508,13 @@ public abstract class GUIObject extends Renderable<GUIObject> {
     }
 
     final void mouseScrolledAll(int amount) {
-        if (disabled)
+        if (disabled) {
+            // A disabled control should not eat the wheel: let it bubble to a scrollable ancestor.
+            GUIObject parent = getParent();
+            if (parent != null)
+                parent.mouseScrolledAll(amount);
             return;
+        }
         mouseScrolled(amount);
         for (var listener : listeners) {
             if (listener instanceof MouseWheelListener l) {

--- a/tt/src/main/java/com/oddlabs/tt/gui/PulldownButton.java
+++ b/tt/src/main/java/com/oddlabs/tt/gui/PulldownButton.java
@@ -105,10 +105,19 @@ public final class PulldownButton<T> extends GUIObject {
         label.setColor(color);
     }
 
-    private void itemChosen(@NonNull PulldownMenu<T> menu, int item_index) {
-        PulldownItem<T> item = menu.getItem(item_index);
+    // Sync the selection from external state without firing item-chosen listeners, so an open menu stays open.
+    public void setSelected(int index) {
+        menu.chooseItemSilently(index);
+        applyLabel(menu.getItem(index));
+    }
+
+    private void applyLabel(@NonNull PulldownItem<T> item) {
         label.set(item.getLabelString());
         label.setColor(item.getLabelColor());
+    }
+
+    private void itemChosen(@NonNull PulldownMenu<T> menu, int item_index) {
+        applyLabel(menu.getItem(item_index));
         if (menu.isActive())
             deactivateMenu();
     }

--- a/tt/src/main/java/com/oddlabs/tt/gui/PulldownMenu.java
+++ b/tt/src/main/java/com/oddlabs/tt/gui/PulldownMenu.java
@@ -92,6 +92,12 @@ public class PulldownMenu<T> extends Group {
         itemChosenAll();
     }
 
+    // Update the selection without notifying listeners, for programmatic state sync that must not run the
+    // user-selection side effects (closing an open menu, resending the slot to the server).
+    public void chooseItemSilently(int index) {
+        chosen_item_index = index;
+    }
+
     @Override
     protected void focusNotify(boolean focus) {
         if (!focus) {

--- a/tt/src/main/java/com/oddlabs/tt/gui/ScrollButton.java
+++ b/tt/src/main/java/com/oddlabs/tt/gui/ScrollButton.java
@@ -18,8 +18,8 @@ public final class ScrollButton extends GUIObject {
 
     @Override
     public void handleInput(@NonNull InputEvent event) {
-        if (event.hasAction(GameAction.UI_FOCUS_NEXT)) {
-            // Bubble Tab
+        if (event.hasAction(GameAction.UI_FOCUS_NEXT) || event.hasAction(GameAction.UI_CANCEL)) {
+            // Bubble Tab and Escape
             return;
         }
         // Swallow others


### PR DESCRIPTION
**PulldownButton and PulldownMenu selection improvements:**

* Added a new `setSelected` method to `PulldownButton` that updates the selected item without firing item-chosen listeners, preventing unwanted side effects like closing an open menu or resending data to the server. This method uses the new `chooseItemSilently` method in `PulldownMenu`, which updates the selection without notifying listeners. 
* Updated `GameMenu` to use `setSelected` instead of directly choosing items via the menu, ensuring that UI state changes do not trigger unnecessary logic.

**Input event handling enhancements:**

* Modified `ArrowButton` and `ScrollButton` to also bubble the Escape key (`UI_CANCEL` action)

**Mouse wheel event propagation:**

* Updated `GUIObject` so that disabled controls no longer consume mouse wheel events. Instead, these events are passed up to scrollable ancestor controls, improving scroll behavior in nested UI components.