### PR TITLE
Fix closing a player slot in the multiplayer lobby

### DIFF
--- a/tt/src/main/java/com/oddlabs/tt/form/GameMenu.java
+++ b/tt/src/main/java/com/oddlabs/tt/form/GameMenu.java
@@ -214,7 +214,7 @@ public final class GameMenu extends Panel implements ConfigurationListener, Chat
             case CLOSED_INDEX:
                 if (player.getType() != PlayerSlot.CLOSED || race_changed || team_changed) {
                     slot_button.getMenu().getItem(OPEN_INDEX).setLabelString(i18n("open"));
-                    slot_button.getMenu().chooseItem(OPEN_INDEX);
+                    game_network.getClient().getServerInterface().resetSlotState(player_slot, false);
                 }
                 break;
             case COMPUTER_EASY_INDEX:


### PR DESCRIPTION
## Problem

In the multiplayer lobby (`GameMenu`), the host can no longer close a player slot. Selecting **Closed** silently reverts the slot to **Open**, so joiners can still take it.

## Cause

In the GUI refactor (`b686f7fb`), the `CLOSED_INDEX` branch of `GameMenu.adjustPlayerSlot` had its server call replaced with a UI-only reselect:

```diff
 case CLOSED_INDEX:
     if (player.getType() != PlayerSlot.CLOSED || race_changed || team_changed) {
         slot_button.getMenu().getItem(OPEN_INDEX).setLabelString(i18n("open"));
-        game_network.getClient().getServerInterface().resetSlotState(player_slot, false);
+        slot_button.getMenu().chooseItem(OPEN_INDEX);
     }
```

`setPlayerSlot` only accepts HUMAN/AI, so closing a slot must go through `resetSlotState(slot, false)` (Server.java). With that call gone, nothing tells the server to close the slot.

## Fix

Restore the `resetSlotState(player_slot, false)` call so a closed slot actually closes and rejects joiners.