### PR TITLE
Respect game speed setting in singleplayer and multiplayer

### DIFF
--- a/tt/src/main/java/com/oddlabs/tt/form/AbstractOptionsMenu.java
+++ b/tt/src/main/java/com/oddlabs/tt/form/AbstractOptionsMenu.java
@@ -77,5 +77,6 @@ public abstract class AbstractOptionsMenu extends Form {
 
     protected void changeGamespeed(int index) {
         com.oddlabs.tt.global.Globals.gamespeed = index;
+        Settings.getSettings().gamespeed = index;
     }
 }

--- a/tt/src/main/java/com/oddlabs/tt/form/TerrainMenu.java
+++ b/tt/src/main/java/com/oddlabs/tt/form/TerrainMenu.java
@@ -188,7 +188,10 @@ public final class TerrainMenu extends Group {
         pm_gamespeed.addItem(new PulldownItem<>(ServerMessageBundler.getGamespeedString(Game.GAMESPEED_NORMAL)));
         pm_gamespeed.addItem(new PulldownItem<>(ServerMessageBundler.getGamespeedString(Game.GAMESPEED_FAST)));
         pm_gamespeed.addItem(new PulldownItem<>(ServerMessageBundler.getGamespeedString(Game.GAMESPEED_LUDICROUS)));
-        var pb_gamespeed = new PulldownButton<>(gui_root, pm_gamespeed, 1, 150);
+        // Default the pulldown to the player's game speed setting from the options menu.
+        int gamespeed_index = Math.clamp(Globals.gamespeed - Game.GAMESPEED_SLOW, 0,
+                Game.GAMESPEED_LUDICROUS - Game.GAMESPEED_SLOW);
+        var pb_gamespeed = new PulldownButton<>(gui_root, pm_gamespeed, gamespeed_index, 150);
         group_gamespeed.addChild(pb_gamespeed);
         label_gamespeed.place();
         pb_gamespeed.place(label_gamespeed, RIGHT_MID);

--- a/tt/src/main/java/com/oddlabs/tt/global/Settings.java
+++ b/tt/src/main/java/com/oddlabs/tt/global/Settings.java
@@ -1,5 +1,6 @@
 package com.oddlabs.tt.global;
 
+import com.oddlabs.matchmaking.Game;
 import com.oddlabs.matchmaking.MatchmakingServerInterface;
 import com.oddlabs.tt.event.LocalEventQueue;
 import com.oddlabs.tt.render.Renderer;
@@ -74,6 +75,9 @@ public final class Settings implements Serializable {
     public boolean aggressive_units = false;
     public boolean show_compass = true;
     public boolean confine_cursor = true;
+
+    // gameplay
+    public int gamespeed = Game.GAMESPEED_NORMAL;
 
     public float mapmode_delay = .5f;
     public float tooltip_delay = .5f;
@@ -223,6 +227,7 @@ public final class Settings implements Serializable {
         setProperty(props, "aggressive_units", aggressive_units, defaults.aggressive_units);
         setProperty(props, "show_compass", show_compass, defaults.show_compass);
         setProperty(props, "confine_cursor", confine_cursor, defaults.confine_cursor);
+        setProperty(props, "gamespeed", gamespeed, defaults.gamespeed);
         setProperty(props, "mapmode_delay", mapmode_delay, defaults.mapmode_delay);
         setProperty(props, "tooltip_delay", tooltip_delay, defaults.tooltip_delay);
         setProperty(props, "ui_scale", ui_scale, defaults.ui_scale);
@@ -287,6 +292,7 @@ public final class Settings implements Serializable {
         aggressive_units = getBoolean(props, "aggressive_units", aggressive_units);
         show_compass = getBoolean(props, "show_compass", show_compass);
         confine_cursor = getBoolean(props, "confine_cursor", confine_cursor);
+        gamespeed = getInt(props, "gamespeed", gamespeed);
         mapmode_delay = getFloat(props, "mapmode_delay", mapmode_delay);
         tooltip_delay = getFloat(props, "tooltip_delay", tooltip_delay);
         ui_scale = getFloat(props, "ui_scale", ui_scale);

--- a/tt/src/main/java/com/oddlabs/tt/render/Renderer.java
+++ b/tt/src/main/java/com/oddlabs/tt/render/Renderer.java
@@ -550,6 +550,7 @@ public final class Renderer implements AutoCloseable {
             language = "en";
         Locale.setDefault(Locale.of(language));
         Settings.setSettings(settings);
+        Globals.gamespeed = settings.gamespeed;
         Path last_event_log_dir = settings.last_event_log_dir;
         boolean crashed = settings.crashed;
         NetworkSelector network = new NetworkSelector(LocalEventQueue.getQueue().getDeterministic(),


### PR DESCRIPTION
Closes #188

@
## What

The game speed setting in the options menu now actually sticks and is honored everywhere.

- **Singleplayer:** the option is now persisted to the settings file and loaded on startup (`Settings.gamespeed`), so a new singleplayer game starts at your chosen speed instead of always defaulting to Normal after a restart.
- **Multiplayer:** the host game-creation pulldown now defaults to your options speed instead of a hardcoded Normal.

## Why

Previously the options menu only wrote the speed to `Globals.gamespeed`, a runtime-only field. It worked within a single session for singleplayer, but the value was never saved, so every restart reset it to Normal, and multiplayer creation ignored it entirely.

## Changes

- `Settings`: add `gamespeed` field with save/load.
- `Renderer`: initialize `Globals.gamespeed` from settings on startup.
- `AbstractOptionsMenu`: write the chosen speed back to `Settings` so it persists on close.
- `TerrainMenu`: default the multiplayer speed pulldown to the options setting (clamped to the available range).
@