### PR TITLE
Fix Steam multiplayer stat pushes (wrong SteamID + over-strict AI gate)

### DIFF
--- a/server/src/main/java/com/oddlabs/matchserver/SteamAuthValidator.java
+++ b/server/src/main/java/com/oddlabs/matchserver/SteamAuthValidator.java
@@ -22,7 +22,7 @@ public final class SteamAuthValidator {
     private static final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
 
     // Steam ID 64 base offset (converts account ID to full Steam ID)
-    private static final long STEAM_ID_BASE = 76561197960265728L;
+    public static final long STEAM_ID_BASE = 76561197960265728L;
 
     public static boolean validateTicket(long steamAccountId, byte[] authTicket, int appId) {
         if (authTicket == null || authTicket.length == 0) {

--- a/server/src/main/java/com/oddlabs/matchserver/TimestampedGameSession.java
+++ b/server/src/main/java/com/oddlabs/matchserver/TimestampedGameSession.java
@@ -491,19 +491,17 @@ public final class TimestampedGameSession {
             return;
         }
 
-        // Only count games with all human players (no AI)
-        if (session.getParticipants().length != session.getPlayerInfo().length) {
-            MatchmakingServer.getLogger().info(
-                    "Game " + database_id + ". Skipping Steam achievements update - game includes AI players");
-            return;
-        }
-
+        // Mirror the DB win/loss accounting. This runs only from teamWon, which
+        // fires when a real human opponent lost, so AI fillers are irrelevant and
+        // pure-vs-AI games never reach here (matching the wins/losses columns).
         Participant[] participants = session.getParticipants();
         for (int i = 0; i < participants.length; i++) {
             String nick = participants[i].getNick();
 
             Long steamId = DBInterface.getSteamIdByNick(nick);
             if (steamId == null) {
+                MatchmakingServer.getLogger().warning(
+                        "Game " + database_id + ". No Steam ID linked for " + nick + ", skipping Steam stats push");
                 continue;
             }
 

--- a/server/src/main/java/com/oddlabs/matchserver/TimestampedGameSession.java
+++ b/server/src/main/java/com/oddlabs/matchserver/TimestampedGameSession.java
@@ -498,8 +498,8 @@ public final class TimestampedGameSession {
         for (int i = 0; i < participants.length; i++) {
             String nick = participants[i].getNick();
 
-            Long steamId = DBInterface.getSteamIdByNick(nick);
-            if (steamId == null) {
+            Long accountId = DBInterface.getSteamIdByNick(nick);
+            if (accountId == null) {
                 MatchmakingServer.getLogger().warning(
                         "Game " + database_id + ". No Steam ID linked for " + nick + ", skipping Steam stats push");
                 continue;
@@ -510,8 +510,11 @@ public final class TimestampedGameSession {
                 int totalLosses = DBInterface.getIntField("losses", nick);
                 int[] streaks = DBInterface.getStreaks(nick);
 
+                // registrations.steam_id stores the 32-bit account ID, but the Steam Web API
+                // requires the full 64-bit SteamID, so add the base offset before pushing.
+                long steamId64 = accountId + SteamAuthValidator.STEAM_ID_BASE;
                 boolean success = SteamAchievementService.updatePlayerStats(
-                        steamId, totalWins, totalLosses, streaks[0], streaks[1]);
+                        steamId64, totalWins, totalLosses, streaks[0], streaks[1]);
 
                 if (success) {
                     MatchmakingServer.getLogger().info(


### PR DESCRIPTION
Multiplayer win/loss/streak stats and their stat-bound achievements never landed on real Steam accounts. Two distinct bugs, both fixed here.

## Bug 1 (root cause): wrong Steam ID sent to the Web API

The client sends the **32-bit account ID** (`SteamManager.getAccountID()`), which is stored verbatim in `registrations.steam_id` and then handed to `SetUserStatsForGame` as `steamid`. That endpoint requires the **64-bit SteamID64**, so every push is rejected.

Verified against live Steam with a publisher key:
- `GetUserStatsForGame` with the SteamID64 `76561198080350673` -> `200`, returns the player's stats.
- Same key, same account, with the account ID `120084945` -> **`400 Bad Request`**.

`SetUserStatsForGame` fails the same way, so `updatePlayerStats` always saw a non-200 and returned false. No stat ever reached a real account through the normal flow.

**Fix:** convert account ID -> SteamID64 at the Web API boundary by adding the base offset (`SteamAuthValidator.STEAM_ID_BASE`, which already existed and is used during ticket validation). Internal lookups (`getSteamIdByNick`, `getProfileNickBySteamId`) stay on the account ID and are unchanged, so no migration is needed.

## Bug 2: push gate stricter than the DB accounting

`updateSteamAchievements` skipped any game containing an AI player:

```java
if (session.getParticipants().length != session.getPlayerInfo().length) return;
```

But `wins`/`losses`/streaks are recorded in `teamWon`, which fires whenever a real human opponent loses, regardless of AI fillers. So a win in a humans-plus-AI game incremented the DB but was never pushed.

**Fix:** remove the AI gate. The push now mirrors the DB exactly (both driven by `teamWon`): human-vs-human results push, AI fillers are irrelevant, and pure solo-vs-AI games reach neither path. Also turns the previously silent "no linked Steam ID" skip into a warning log.

## Notes

- No schema change. Existing players' stats self-correct on their next qualifying win, since the push sends the full `getWins()` total.
- Stat-bound achievements still need their `Max` threshold set in the Steam partner dashboard (e.g. `WIN_1000` must have Max=1000); that is dashboard config, separate from this server fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)