### PR TITLE
Fix armory spinners from showing when nothing is deploying

### DIFF
--- a/tt/src/main/java/com/oddlabs/tt/gui/IconSpinner.java
+++ b/tt/src/main/java/com/oddlabs/tt/gui/IconSpinner.java
@@ -142,7 +142,7 @@ public abstract class IconSpinner extends GUIObject {
 
         renderer.drawIcon(icon_quad.quad(skinMode), x, y);
 
-        if (text_count > 0) {
+        if (computeCount() > 0) {
             var watchQuad = GUIIcons.getIcons().getWatch(getProgress());
             renderer.drawIcon(watchQuad, getWidth() - watchQuad.getWidth(), getHeight() - watchQuad.getHeight());
         }


### PR DESCRIPTION
Fix armory spinners from showing when nothing is deploying