### PR TITLE
Add a differentiation between sim_version (client to client) and api_version (client to server) compatibility

### DIFF
--- a/.github/workflows/build-deploy-server.yml
+++ b/.github/workflows/build-deploy-server.yml
@@ -73,12 +73,13 @@ jobs:
           # rebuild of the same version (e.g. two hotfixes before a bump) still
           # lands in its own releases/ dir on the box.
           BASE=$(grep 'version = "' build.gradle.kts | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          API=$(grep 'API_VERSION' common/src/main/java/com/oddlabs/util/Compatibility.java | sed 's/.*= \([0-9]*\);/\1/')
+          API=$(grep 'API_VERSION =' common/src/main/java/com/oddlabs/util/Compatibility.java | sed 's/.*= \([0-9]*\);/\1/')
+          SIM=$(grep 'SIM_VERSION =' common/src/main/java/com/oddlabs/util/Compatibility.java | sed 's/.*= \([0-9]*\);/\1/')
           VERSION_PATTERN="version = .$(echo "$BASE" | sed 's/\./\\./g')."
           ANCHOR=$(git log --format=%H -G"$VERSION_PATTERN" -- build.gradle.kts | head -1)
           if [ -z "$ANCHOR" ]; then PATCH=0; else PATCH=$(git rev-list --count "${ANCHOR}..HEAD"); fi
           SHORT=$(git rev-parse --short HEAD)
-          echo "tag=v${BASE}.${PATCH}-${API}-${SHORT}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${BASE}.${PATCH}-${API}.${SIM}-${SHORT}" >> "$GITHUB_OUTPUT"
           echo "short=${SHORT}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve deploy target

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to deploy (e.g. v2.0.14-103)'
+        description: 'Release tag to deploy (e.g. v2.0.14-103.1)'
         required: true
         type: string
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -84,7 +84,8 @@ jobs:
         name: Compute version string
         run: |
           BASE=$(grep 'version = "' build.gradle.kts | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          API=$(grep 'API_VERSION' common/src/main/java/com/oddlabs/util/Compatibility.java | sed 's/.*= \([0-9]*\);/\1/')
+          API=$(grep 'API_VERSION =' common/src/main/java/com/oddlabs/util/Compatibility.java | sed 's/.*= \([0-9]*\);/\1/')
+          SIM=$(grep 'SIM_VERSION =' common/src/main/java/com/oddlabs/util/Compatibility.java | sed 's/.*= \([0-9]*\);/\1/')
           # PATCH = commits since the bump commit that introduced the current MAJOR.MINOR.
           VERSION_PATTERN="version = .$(echo "$BASE" | sed 's/\./\\./g')."
           ANCHOR=$(git log --format=%H -G"$VERSION_PATTERN" -- build.gradle.kts | head -1)
@@ -93,8 +94,8 @@ jobs:
           else
             PATCH=$(git rev-list --count "${ANCHOR}..HEAD")
           fi
-          echo "full=v${BASE}.${PATCH}-${API}" >> $GITHUB_OUTPUT
-          echo "Resolved version: v${BASE}.${PATCH}-${API} (base=${BASE}, patch=${PATCH}, api=${API}, anchor=${ANCHOR:-none})"
+          echo "full=v${BASE}.${PATCH}-${API}.${SIM}" >> $GITHUB_OUTPUT
+          echo "Resolved version: v${BASE}.${PATCH}-${API}.${SIM} (base=${BASE}, patch=${PATCH}, api=${API}, sim=${SIM}, anchor=${ANCHOR:-none})"
 
   build-linux:
     needs: [version]

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to promote (e.g. v2.0.14-103)'
+        description: 'Release tag to promote (e.g. v2.0.14-103.1)'
         required: true
         type: string
       deploy_server:

--- a/.github/workflows/steam-publish.yml
+++ b/.github/workflows/steam-publish.yml
@@ -1,0 +1,198 @@
+name: Steam Publish
+
+# Builds the game from a chosen ref and uploads it to a chosen Steam branch of
+# the main game. For feature previews and betas (archipelago, p2p, ...) instead
+# of one-off workflows per feature: keep the feature's configuration (flag
+# flips, SIM_VERSION bump) as commits on the ref being built. The Steam branch
+# must exist on the partner dashboard first (App admin > Steamworks > builds).
+#
+# The regular release pipeline is untouched: `prerelease` and `default` are
+# refused here; pushes to the git release branch remain the only way to publish
+# to Steam prerelease, and promoting to default stays manual on the dashboard.
+#
+# The demo app is intentionally not uploaded here; add a second steam-deploy
+# step with STEAM_DEMO_APP_ID if a matching branch is created on the demo too.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to build from'
+        required: true
+        type: string
+      steam_branch:
+        description: 'Steam branch to publish to (must already exist; prerelease/default refused)'
+        required: true
+        type: string
+
+jobs:
+  show-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show dispatch inputs
+        run: |
+          {
+            echo "## Dispatch inputs"
+            echo "- ref: \`${{ inputs.ref }}\`"
+            echo "- steam_branch: \`${{ inputs.steam_branch }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.compute.outputs.full }}
+    steps:
+      - name: Refuse reserved Steam branches
+        run: |
+          case "${{ inputs.steam_branch }}" in
+            prerelease|default|"")
+              echo "::error::Steam branch '${{ inputs.steam_branch }}' is reserved for the release pipeline"
+              exit 1;;
+          esac
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+      - id: compute
+        name: Compute version string
+        run: |
+          BASE=$(grep 'version = "' build.gradle.kts | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          API=$(grep 'API_VERSION =' common/src/main/java/com/oddlabs/util/Compatibility.java | sed 's/.*= \([0-9]*\);/\1/')
+          SIM=$(grep 'SIM_VERSION =' common/src/main/java/com/oddlabs/util/Compatibility.java | sed 's/.*= \([0-9]*\);/\1/')
+          VERSION_PATTERN="version = .$(echo "$BASE" | sed 's/\./\\./g')."
+          ANCHOR=$(git log --format=%H -G"$VERSION_PATTERN" -- build.gradle.kts | head -1)
+          if [ -z "$ANCHOR" ]; then PATCH=0; else PATCH=$(git rev-list --count "${ANCHOR}..HEAD"); fi
+          echo "full=v${BASE}.${PATCH}-${API}.${SIM}" >> $GITHUB_OUTPUT
+          echo "Resolved version: v${BASE}.${PATCH}-${API}.${SIM}"
+
+  build-windows:
+    needs: [version]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0  # generateBuildInfo needs full history to find the bump-commit anchor
+      - name: Set up JDK 26
+        uses: actions/setup-java@v4
+        with:
+          java-version: '26-ea'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build Windows Package
+        run: ./gradlew :tt:packageWindows
+      - name: Upload files
+        uses: actions/upload-artifact@v4
+        with:
+          name: tribal-trouble-windows_${{ needs.version.outputs.full }}
+          path: tt/build/dist/windows/
+
+  build-linux:
+    needs: [version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0  # generateBuildInfo needs full history to find the bump-commit anchor
+      - name: Set up JDK 26
+        uses: actions/setup-java@v4
+        with:
+          java-version: '26-ea'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build Linux AppImage
+        run: ./gradlew :tt:packageLinux
+      - name: Upload Linux Package
+        uses: actions/upload-artifact@v4
+        with:
+          name: tribal-trouble-linux-package_${{ needs.version.outputs.full }}
+          path: tt/build/dist/linux/TribalTrouble.AppDir
+
+  build-mac-arm64-app:
+    needs: [version]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0  # generateBuildInfo needs full history to find the bump-commit anchor
+      - name: Set up JDK 26
+        uses: actions/setup-java@v4
+        with:
+          java-version: '26-ea'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build mac binaries
+        run: ./gradlew :tt:packageMacArm64App
+      - name: Upload files
+        uses: actions/upload-artifact@v4
+        with:
+          name: tribal-trouble-mac-arm64-app_${{ needs.version.outputs.full }}
+          path: tt/build/dist/macosx-arm64-app/
+
+  build-mac-x86-app:
+    needs: [version]
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0  # generateBuildInfo needs full history to find the bump-commit anchor
+      - name: Set up JDK 26
+        uses: actions/setup-java@v4
+        with:
+          java-version: '26-ea'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build mac binaries
+        run: ./gradlew :tt:packageMacX86App
+      - name: Upload files
+        uses: actions/upload-artifact@v4
+        with:
+          name: tribal-trouble-mac-x86-app_${{ needs.version.outputs.full }}
+          path: tt/build/dist/macosx-x86-app/
+
+  steam-publish:
+    needs: [version, build-windows, build-linux, build-mac-arm64-app, build-mac-x86-app]
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Download Windows Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tribal-trouble-windows_${{ needs.version.outputs.full }}
+          path: tt/build/dist/windows/
+      - name: Download Mac x86 Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tribal-trouble-mac-x86-app_${{ needs.version.outputs.full }}
+          path: tt/build/dist/macosx-x86-app/
+      - name: Download Mac arm64 Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tribal-trouble-mac-arm64-app_${{ needs.version.outputs.full }}
+          path: tt/build/dist/macosx-arm64-app/
+      - name: Download Linux Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tribal-trouble-linux-package_${{ needs.version.outputs.full }}
+          path: tt/build/dist/linux/
+      - name: Upload to steam
+        uses: game-ci/steam-deploy@8bd9baca6407f9abd210bd1eef3c45f56e12d8d9  # v3
+        with:
+          username: ${{ vars.STEAM_USER }}
+          configVdf: ${{ secrets.STEAM_CONFIG_VDF }}
+          appId: ${{ vars.STEAM_APP_ID }}
+          buildDescription: ${{ needs.version.outputs.full }}.${{ github.run_number }}
+          firstDepotIdOverride: 3945722
+          rootPath: tt/build/dist/
+          depot1Path: windows
+          depot2Path: macosx-arm64-app
+          depot3Path: macosx-x86-app
+          depot4Path: linux
+          releaseBranch: ${{ inputs.steam_branch }}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -73,7 +73,7 @@ val generateBuildInfo by tasks.registering {
 
             public final class BuildInfo {
                 public static final String VERSION = "$effectiveVersion";
-                public static final String FULL_VERSION = "v" + VERSION + "-" + Compatibility.API_VERSION;
+                public static final String FULL_VERSION = "v" + VERSION + "-" + Compatibility.API_VERSION + "." + Compatibility.SIM_VERSION;
                 private BuildInfo() {}
             }
 

--- a/common/src/main/java/com/oddlabs/matchmaking/GameHost.java
+++ b/common/src/main/java/com/oddlabs/matchmaking/GameHost.java
@@ -11,6 +11,9 @@ public final class GameHost implements Serializable {
 
     private final @NonNull Game game;
     private final int host_id;
+    // Carries the host's Compatibility.SIM_VERSION. The field keeps its
+    // historical name for serialization stream compatibility with old clients,
+    // which receive it but never read it.
     private final int revision;
 
     public GameHost(@NonNull Game game, int host_id, int revision) {
@@ -27,7 +30,7 @@ public final class GameHost implements Serializable {
         return host_id;
     }
 
-    public int getRevision() {
+    public int getSimVersion() {
         return revision;
     }
 }

--- a/common/src/main/java/com/oddlabs/matchmaking/MatchmakingServerLoginInterface.java
+++ b/common/src/main/java/com/oddlabs/matchmaking/MatchmakingServerLoginInterface.java
@@ -13,4 +13,6 @@ public interface MatchmakingServerLoginInterface {
     void loginWithSteam(long steamAccountId, String personaName, byte[] authTicket, int appId, int revision);
 
     void createUser(Login login, LoginDetails login_details, SignedObject reg_key, int revision);
+
+    void setSimVersion(int sim_version);
 }

--- a/common/src/main/java/com/oddlabs/util/Compatibility.java
+++ b/common/src/main/java/com/oddlabs/util/Compatibility.java
@@ -1,5 +1,25 @@
 package com.oddlabs.util;
 
 public final class Compatibility {
+    /**
+     * Server-client wire protocol version. Checked at login with strict equality;
+     * a mismatch rejects the client with a "please update" error. Bump when the
+     * matchmaking wire (ARMI interfaces or serialized classes) changes
+     * incompatibly. A bump requires the server to be rebuilt and deployed from
+     * the bumped ref, and locks out all older clients.
+     */
     public static final int API_VERSION = 103;
+
+    /**
+     * Client-client gameplay determinism version. Reported to the server after
+     * connecting (setSimVersion); the server only lists and joins games between
+     * clients with equal values. Clients too old to report one are assigned
+     * {@link #SIM_LEGACY}. Bump when a change alters lockstep simulation
+     * behavior (model, pathfinding, landscape generation, behaviours). Needs no
+     * server deploy and locks nobody out.
+     */
+    public static final int SIM_VERSION = 1;
+
+    /** Sim version assumed for clients that predate sim version reporting. */
+    public static final int SIM_LEGACY = 0;
 }

--- a/database/005.AddGameSimVersion.sql
+++ b/database/005.AddGameSimVersion.sql
@@ -1,0 +1,7 @@
+-- Migration 005: Record the host's sim version per game
+-- 0 means legacy: hosted by a client that predates sim version reporting,
+-- or recorded before this migration.
+USE oddlabs;
+
+ALTER TABLE games
+  ADD COLUMN sim_version INT NOT NULL DEFAULT 0;

--- a/database/rollback/005.Rollback.sql
+++ b/database/rollback/005.Rollback.sql
@@ -1,0 +1,5 @@
+-- Rollback for migration 005: Record the host's sim version per game
+USE oddlabs;
+
+ALTER TABLE games
+  DROP COLUMN sim_version;

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -88,6 +88,10 @@ To re-deploy an older release (e.g., the just-promoted one breaks something):
 
 The promote workflow always pulls from GitHub Release assets, so any past release tag is a valid rollback target. No rebuild needed; rollback takes ~2 minutes plus the manual Steam click.
 
+## Publishing feature betas to Steam
+
+Dispatch **Steam Publish** (`steam-publish.yml`) with a git ref and a target Steam branch to put a feature preview (archipelago, p2p, ...) on Steam without touching the release pipeline. The feature's configuration (flag flips, `SIM_VERSION` bump) lives as commits on the ref being built, not as pipeline options. The Steam branch must already exist on the partner dashboard, `prerelease` and `default` are refused, and the upload waits on the same `release` environment approval as everything else. Main game only; the demo needs its own steam-deploy step if ever wanted.
+
 ## Versioning
 
 The canonical release identifier is **`v<MAJOR>.<MINOR>.<PATCH>-<API>.<SIM>`** (e.g., `v2.0.3-103.1`) and shows up everywhere: git tags, GitHub Release titles, artifact names, Steam build descriptions, the in-game About screen, and the matchmaker server logs.
@@ -138,13 +142,13 @@ Create under **Settings → Environments → release** with required reviewers s
 
 ## Security notes
 
-- `game-ci/steam-deploy` is pinned to a commit SHA, not the `v3` tag, so a compromised upstream release can't silently swap action code under our `STEAM_CONFIG_VDF`. To bump: `gh api repos/game-ci/steam-deploy/git/refs/tags/v3 --jq '.object.sha'`, update both pin sites in `gradle.yml`, and leave the tag in a `# v3` trailing comment.
+- `game-ci/steam-deploy` is pinned to a commit SHA, not the `v3` tag, so a compromised upstream release can't silently swap action code under our `STEAM_CONFIG_VDF`. To bump: `gh api repos/game-ci/steam-deploy/git/refs/tags/v3 --jq '.object.sha'`, update the pin sites in `gradle.yml` and `steam-publish.yml`, and leave the tag in a `# v3` trailing comment.
 - First-party `actions/*` (checkout, setup-java, download-artifact, etc.) are conventionally trusted at major-version tags and aren't pinned.
 - Branch protection should restrict who can push to `release`. The `prerelease-gate` approval is defense-in-depth, not the primary access control.
 
 ## Where to find things
 
-- **Workflows**: `.github/workflows/gradle.yml`, `.github/workflows/promote-release.yml`
+- **Workflows**: `.github/workflows/gradle.yml`, `.github/workflows/promote-release.yml`, `.github/workflows/steam-publish.yml`
 - **Build version logic**: `build.gradle.kts` (root, computes BuildInfo) + `version` job in `gradle.yml`
 - **API guard**: tracked wire-protocol interfaces are listed in the `api-guard` job's `INTERFACE_FILES` array; compatible changes can be acknowledged without a bump via `[api-compat-ack]` commits (see [Cutting a release](#1-bump-version-metadata-if-needed))
 - **Website homepage** (download links pointing at the stable URLs): upstream `Tribal-Trouble/tribaltrouble` → branch `new_main` → `website/index.html`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -24,7 +24,7 @@ Everything below assumes you're working from `main` with the changes ready to sh
 
 ### 1. Bump version metadata if needed
 
-The release tag is `v<MAJOR>.<MINOR>.<PATCH>-<API>` (see [Versioning](#versioning)).
+The release tag is `v<MAJOR>.<MINOR>.<PATCH>-<API>.<SIM>` (see [Versioning](#versioning)).
 
 - **New minor or major release** (e.g., `2.0` → `2.1`): edit `version = "..."` in the root `build.gradle.kts`. PATCH resets to `0` automatically.
 - **API/protocol change**: bump `API_VERSION` in `common/src/main/java/com/oddlabs/util/Compatibility.java`. The `api-guard` CI job will fail your build if you changed a wire-protocol interface without bumping this. If the interface change is wire compatible (e.g., an addition old clients never call) and doesn't warrant a bump, a maintainer can instead record that decision with an empty ack commit:
@@ -60,7 +60,7 @@ Test on the prerelease as long as you want. When you're confident, move on.
 
 ### 4. Promote to stable
 
-Open the GitHub Actions tab → **Promote Release to Stable** → **Run workflow**. Enter the tag (e.g. `v2.0.14-103`). You can copy the tag from the GitHub Releases page or the workflow run that produced it.
+Open the GitHub Actions tab → **Promote Release to Stable** → **Run workflow**. Enter the tag (e.g. `v2.0.14-103.1`). You can copy the tag from the GitHub Releases page or the workflow run that produced it.
 
 The workflow:
 
@@ -83,24 +83,25 @@ Find the build matching the tag you promoted, change its branch from `prerelease
 
 To re-deploy an older release (e.g., the just-promoted one breaks something):
 
-1. Run **Promote Release to Stable** again with the previous good tag (e.g. `v2.0.13-103`).
+1. Run **Promote Release to Stable** again with the previous good tag (e.g. `v2.0.13-103.1`).
 2. On the Steam partner dashboard, move the older build back to `default`.
 
 The promote workflow always pulls from GitHub Release assets, so any past release tag is a valid rollback target. No rebuild needed; rollback takes ~2 minutes plus the manual Steam click.
 
 ## Versioning
 
-The canonical release identifier is **`v<MAJOR>.<MINOR>.<PATCH>-<API>`** (e.g., `v2.0.3-102`) and shows up everywhere: git tags, GitHub Release titles, artifact names, Steam build descriptions, the in-game About screen, and the matchmaker server logs.
+The canonical release identifier is **`v<MAJOR>.<MINOR>.<PATCH>-<API>.<SIM>`** (e.g., `v2.0.3-103.1`) and shows up everywhere: git tags, GitHub Release titles, artifact names, Steam build descriptions, the in-game About screen, and the matchmaker server logs.
 
-It's built from three sources:
+It's built from four sources:
 
 - **MAJOR.MINOR**: `version = "2.0"` in the root `build.gradle.kts`. Bump manually for a minor or major release.
 - **PATCH**: auto-computed as the number of commits since the commit that introduced the current `version = "<MAJOR>.<MINOR>"` line in `build.gradle.kts`. Every commit on top of the bump advances it by one.
-- **API**: `public static final int API_VERSION = 102;` in `common/src/main/java/com/oddlabs/util/Compatibility.java`. Bump only when the wire protocol between client and server changes (mismatched clients get rejected at login).
+- **API**: `API_VERSION` in `common/src/main/java/com/oddlabs/util/Compatibility.java`. Bump only when the wire protocol between client and server changes incompatibly (mismatched clients get rejected at login; a bump requires a server deploy from the bumped ref).
+- **SIM**: `SIM_VERSION` in the same file. Bump when a change alters lockstep simulation behavior (model, pathfinding, landscape generation, behaviours). Needs no server deploy; the server only lists and joins games between clients with equal sim versions. Clients too old to report one are treated as sim `0` (legacy).
 
 Both Gradle and CI compute PATCH from the same git history using identical logic (`git log -G'version = .<BASE>.' -- build.gradle.kts | head -1` as the anchor, then `git rev-list --count <anchor>..HEAD`), so the value the game and servers log (from the generated `BuildInfo.java` under `common/build/generated/sources/buildinfo/`) always matches the git tag and Steam build description of the build it came from.
 
-When you bump `MAJOR.MINOR` (say `2.0` → `2.1`), that bump commit becomes the new anchor. PATCH is `0` at the bump (yielding `v2.1.0-102`), `1` after the next commit (`v2.1.1-102`), and so on.
+When you bump `MAJOR.MINOR` (say `2.0` → `2.1`), that bump commit becomes the new anchor. PATCH is `0` at the bump (yielding `v2.1.0-103.1`), `1` after the next commit (`v2.1.1-103.1`), and so on.
 
 ## Required repository configuration
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,7 +27,7 @@ Everything below assumes you're working from `main` with the changes ready to sh
 The release tag is `v<MAJOR>.<MINOR>.<PATCH>-<API>.<SIM>` (see [Versioning](#versioning)).
 
 - **New minor or major release** (e.g., `2.0` → `2.1`): edit `version = "..."` in the root `build.gradle.kts`. PATCH resets to `0` automatically.
-- **API/protocol change**: bump `API_VERSION` in `common/src/main/java/com/oddlabs/util/Compatibility.java`. The `api-guard` CI job will fail your build if you changed a wire-protocol interface without bumping this. If the interface change is wire compatible (e.g., an addition old clients never call) and doesn't warrant a bump, a maintainer can instead record that decision with an empty ack commit:
+- **API/protocol change**: bump `API_VERSION` in `common/src/main/java/com/oddlabs/util/Compatibility.java`. The `api-guard` CI job will fail your build if you changed a wire-protocol interface without bumping this. If the interface change is wire compatible and doesn't warrant a bump, a maintainer can instead record that decision with an empty ack commit. (ARMI dispatches by index into the interface's methods sorted by name, so an added method is only compatible if its name sorts after every method ever shipped in that interface; anything else shifts old clients' indices and needs the bump.)
 
   ```bash
   git commit --allow-empty -m "<why the change is compatible> [api-compat-ack]"
@@ -102,6 +102,12 @@ It's built from four sources:
 Both Gradle and CI compute PATCH from the same git history using identical logic (`git log -G'version = .<BASE>.' -- build.gradle.kts | head -1` as the anchor, then `git rev-list --count <anchor>..HEAD`), so the value the game and servers log (from the generated `BuildInfo.java` under `common/build/generated/sources/buildinfo/`) always matches the git tag and Steam build description of the build it came from.
 
 When you bump `MAJOR.MINOR` (say `2.0` → `2.1`), that bump commit becomes the new anchor. PATCH is `0` at the bump (yielding `v2.1.0-103.1`), `1` after the next commit (`v2.1.1-103.1`), and so on.
+
+### Bumping SIM_VERSION
+
+No CI guard is practical for sim compatibility; it is a review judgment. Rule of thumb: any change under `model/`, `pathfinder/`, `behaviour/`, or landscape/procedural generation that alters how game state evolves needs a `SIM_VERSION` bump. A bump needs no server deploy and locks nobody out; clients on different sim versions simply stop seeing each other's games. The number is a global claim of compatibility: every build that ships a given sim version promises bit-identical simulation with every other build shipping it, so concurrent feature betas must each take their own value.
+
+Sim versions are client-reported and unauthenticated. This is a coordination fence for honest clients, not a security boundary; a modified client that lies ends up in desynced (invalid) games, which is a moderation problem, not a protocol one.
 
 ## Required repository configuration
 

--- a/server/src/main/java/com/oddlabs/matchserver/Authenticator.java
+++ b/server/src/main/java/com/oddlabs/matchserver/Authenticator.java
@@ -27,6 +27,7 @@ public final class Authenticator implements MatchmakingServerLoginInterface, Con
             MatchmakingServerLoginInterface.class);
     private final int host_id;
     private InetAddress local_remote_address;
+    private int sim_version = com.oddlabs.util.Compatibility.SIM_LEGACY;
 
     public Authenticator(MatchmakingServer server, SecureConnection conn, InetAddress remote_address, int host_id) {
         this.conn = conn;
@@ -63,6 +64,10 @@ public final class Authenticator implements MatchmakingServerLoginInterface, Con
 
     public void setLocalRemoteAddress(InetAddress local_remote_address) {
         this.local_remote_address = local_remote_address;
+    }
+
+    public void setSimVersion(int sim_version) {
+        this.sim_version = sim_version;
     }
 
     public static void checkUsername(String name) throws InvalidUsernameException {
@@ -200,7 +205,7 @@ public final class Authenticator implements MatchmakingServerLoginInterface, Con
         if (local_remote_address != null) {
             client_interface.loginOK(username, new TunnelAddress(getHostID(), remote_address, local_remote_address));
             server.loginClient(remote_address, local_remote_address, username, conn.getWrappedConnectionAndShutdown(),
-                    revision, host_id);
+                    revision, sim_version, host_id);
         } else {
             error(new IllegalStateException("Client didnt set local_remote_address"));
         }

--- a/server/src/main/java/com/oddlabs/matchserver/Client.java
+++ b/server/src/main/java/com/oddlabs/matchserver/Client.java
@@ -562,7 +562,7 @@ public final class Client implements MatchmakingServerInterface, ConnectionInter
             current_game = game;
             game_hosts.add(this);
             MatchmakingServer.getLogger().info("Game registered, name = " + current_game.getName());
-            DBInterface.createGame(game, getProfile().getNick());
+            DBInterface.createGame(game, getProfile().getNick(), sim_version);
 
             if (current_room != null) {
                 String formatted_message = getProfile().getNick() + " has created a game called \"" + current_game.getName() + "\".";

--- a/server/src/main/java/com/oddlabs/matchserver/Client.java
+++ b/server/src/main/java/com/oddlabs/matchserver/Client.java
@@ -52,6 +52,7 @@ public final class Client implements MatchmakingServerInterface, ConnectionInter
     private int update_key = 0;
 
     private final int revision;
+    private final int sim_version;
     private final String username;
     private final boolean guest;
     private @Nullable Profile active_profile;
@@ -62,7 +63,8 @@ public final class Client implements MatchmakingServerInterface, ConnectionInter
     private @Nullable ChatRoom current_room;
 
     public Client(@NonNull MatchmakingServer server, AbstractConnection conn, InetAddress remote_address,
-            InetAddress local_remote_address, String username, boolean guest, int revision, int host_id) {
+            InetAddress local_remote_address, String username, boolean guest, int revision, int sim_version,
+            int host_id) {
         this.conn = conn;
         this.server = server;
         this.remote_address = remote_address;
@@ -72,6 +74,7 @@ public final class Client implements MatchmakingServerInterface, ConnectionInter
         this.username = username;
         this.guest = guest;
         this.revision = revision;
+        this.sim_version = sim_version;
         this.host_id = host_id;
         conn.setConnectionInterface(this);
     }
@@ -389,8 +392,8 @@ public final class Client implements MatchmakingServerInterface, ConnectionInter
         return remote_address;
     }
 
-    private int getRevision() {
-        return revision;
+    public int getSimVersion() {
+        return sim_version;
     }
 
     public void requestList(int type, int update_key) {
@@ -409,8 +412,7 @@ public final class Client implements MatchmakingServerInterface, ConnectionInter
                     Client client = (Client) it.next();
                     Game game = client.getCurrentGame();
                     int host_id = client.getHostID();
-                    int game_revision = client.getRevision();
-                    game_hosts_chunk[chunk_index++] = new GameHost(game, host_id, game_revision);
+                    game_hosts_chunk[chunk_index++] = new GameHost(game, host_id, client.getSimVersion());
                     if (chunk_index == game_hosts_chunk.length) {
                         client_interface.updateList(type, game_hosts_chunk);
                         chunk_index = 0;

--- a/server/src/main/java/com/oddlabs/matchserver/Client.java
+++ b/server/src/main/java/com/oddlabs/matchserver/Client.java
@@ -410,6 +410,8 @@ public final class Client implements MatchmakingServerInterface, ConnectionInter
                 GameHost[] game_hosts_chunk = new GameHost[CHUNK_SIZE];
                 while (it.hasNext()) {
                     Client client = (Client) it.next();
+                    // Only advertise games this client can actually play
+                    if (client.getSimVersion() != sim_version) continue;
                     Game game = client.getCurrentGame();
                     int host_id = client.getHostID();
                     game_hosts_chunk[chunk_index++] = new GameHost(game, host_id, client.getSimVersion());
@@ -479,7 +481,9 @@ public final class Client implements MatchmakingServerInterface, ConnectionInter
         HostSequenceID host_seq_id = new HostSequenceID(getHostID(), seq);
         Client client = server.getClientFromID(address_to);
         tunnels.put(host_seq_id, client);
-        if (client != null) {
+        // Refuse tunnels to sim-incompatible game hosts; the filtered game list
+        // already hides them, this guards clients that bypass it
+        if (client != null && (!game_hosts.contains(client) || client.getSimVersion() == sim_version)) {
             client.tunnelOpened(host_seq_id, remote_address, local_remote_address, active_profile, this);
         } else
             tunnelClosed(host_seq_id);

--- a/server/src/main/java/com/oddlabs/matchserver/DBInterface.java
+++ b/server/src/main/java/com/oddlabs/matchserver/DBInterface.java
@@ -527,9 +527,9 @@ public final class DBInterface {
         }
     }
 
-    public static void createGame(Game game, String nick) {
+    public static void createGame(Game game, String nick, int sim_version) {
         try (Connection conn = DBUtils.createDatabaseConnection(); PreparedStatement stmt = conn.prepareStatement(
-                "INSERT INTO games (time_create, name, rated, speed, size, hills," + " trees, resources, mapcode, status) VALUES (?, ?, ?, ?, ?, ?, ?," + " ?, ?, ?)",
+                "INSERT INTO games (time_create, name, rated, speed, size, hills," + " trees, resources, mapcode, status, sim_version) VALUES (?, ?, ?, ?, ?, ?, ?," + " ?, ?, ?, ?)",
                 java.sql.Statement.RETURN_GENERATED_KEYS)) {
             stmt.setTimestamp(1, new Timestamp(System.currentTimeMillis()));
             stmt.setString(2, game.getName());
@@ -541,6 +541,7 @@ public final class DBInterface {
             stmt.setInt(8, game.getSupplies());
             stmt.setString(9, game.getMapcode());
             stmt.setString(10, "created");
+            stmt.setInt(11, sim_version);
 
             stmt.executeUpdate();
             try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {

--- a/server/src/main/java/com/oddlabs/matchserver/MatchmakingServer.java
+++ b/server/src/main/java/com/oddlabs/matchserver/MatchmakingServer.java
@@ -103,14 +103,14 @@ public final class MatchmakingServer implements ConnectionListenerInterface {
 //	}
 
     public void loginClient(InetAddress remote_address, InetAddress local_remote_address, String username,
-            AbstractConnection conn, int revision, int host_id) {
+            AbstractConnection conn, int revision, int sim_version, int host_id) {
         Client old_logged_in = online_users.remove(username.toLowerCase());
         if (old_logged_in != null) {
             old_logged_in.close();
             logger.info(username + " overtaked old login");
         }
         Client client = new Client(this, conn, remote_address, local_remote_address, username, false, revision,
-                host_id);
+                sim_version, host_id);
         online_users.put(username.toLowerCase(), client);
         client_map.put(client.getHostID(), client);
         logger.info(username + " logged in");

--- a/tt/src/main/java/com/oddlabs/tt/net/MatchmakingClient.java
+++ b/tt/src/main/java/com/oddlabs/tt/net/MatchmakingClient.java
@@ -500,6 +500,7 @@ public final class MatchmakingClient implements MatchmakingClientInterface, Conn
         matchmaking_login_interface.setLocalRemoteAddress(wrapped_connection.getLocalAddress());
         IO.println("wrapped_connection.getLocalAddress() = " + wrapped_connection.getLocalAddress());
         int revision = com.oddlabs.util.Compatibility.API_VERSION;
+        matchmaking_login_interface.setSimVersion(com.oddlabs.util.Compatibility.SIM_VERSION);
 
         if (steamLogin) {
             SteamManager steam = SteamManager.getInstance();

--- a/tt/src/main/java/com/oddlabs/tt/procedural/Landscape.java
+++ b/tt/src/main/java/com/oddlabs/tt/procedural/Landscape.java
@@ -641,7 +641,7 @@ public final class Landscape {
         if (DEBUG) slope.copy().dynamicRange().toLayer().saveAsPNG("slope");
         relheight = height.copy().relativeIntensityNormalized(Math.max(1, unit_grids_per_world >> 5));
         if (DEBUG) relheight.toLayer().saveAsPNG("relheight");
-        if (Globals.SHIPS_ENABLED) {
+        if (archipelago) {
             access = generateThresholdMap(slope, access_threshold);
         } else {
             access = generateThresholdMap(slope, access_threshold).largestConnected(1f);
@@ -718,7 +718,7 @@ public final class Landscape {
         if (DEBUG) slope.copy().dynamicRange().toLayer().saveAsPNG("slope");
         relheight = height.copy().relativeIntensityNormalized(Math.max(1, unit_grids_per_world >> 5));
         if (DEBUG) relheight.toLayer().saveAsPNG("relheight");
-        if (Globals.SHIPS_ENABLED) {
+        if (archipelago) {
             access = generateThresholdMap(slope, access_threshold);
         } else {
             access = generateThresholdMap(slope, access_threshold).largestConnected(1f);


### PR DESCRIPTION
Adds a differentiation between sim_version (client to client) and api_version (client to server) compatibility for releasing

- setSimVersion on the login interface, threaded through to the server Client (legacy defaults to 0)
- server filters the game list and refuses join tunnels across sim versions
- games table records the host's sim_version (migration 005)
- access map generation keyed off the game's archipelago flag instead of SHIPS_ENABLED so identical settings generate identical maps on every build
- release identity is now v<base>.<patch>-<api>.<sim>
- releasing.md documents when to bump which