### PR TITLE
Shorten /bannedwords match type choice names

### DIFF
--- a/server/src/main/java/com/oddlabs/matchserver/discord/commands/BannedWordsCommand.java
+++ b/server/src/main/java/com/oddlabs/matchserver/discord/commands/BannedWordsCommand.java
@@ -113,16 +113,16 @@ public class BannedWordsCommand extends DiscordCommand {
                 .required(true)
                 .build();
         ApplicationCommandOptionChoiceData substring_choice = ApplicationCommandOptionChoiceData.builder()
-                .name("substring - matches anywhere, only for words with no innocent uses")
+                .name("substring")
                 .value(BannedWordFilter.MATCH_SUBSTRING)
                 .build();
         ApplicationCommandOptionChoiceData exact_choice = ApplicationCommandOptionChoiceData.builder()
-                .name("exact - matches whole names/words only")
+                .name("exact")
                 .value(BannedWordFilter.MATCH_EXACT)
                 .build();
         ApplicationCommandOptionData match_type_option = ApplicationCommandOptionData.builder()
                 .name(command_option_match_type)
-                .description("How the word is matched")
+                .description("substring matches anywhere (only for words with no innocent uses); exact matches whole names/words")
                 .type(ApplicationCommandOption.Type.STRING.getValue())
                 .required(true)
                 .addChoice(substring_choice)


### PR DESCRIPTION
Discord choices can't have descriptions, so the long explanatory choice names in /bannedwords add looked clunky in the picker. Renamed the choices to just `substring` and `exact` and moved the guidance into the match_type option description, which Discord shows above the picker anyway.

No behavior change - the choice values are the same, so existing entries and the filter are unaffected. Command registration will update the choice labels on next server start.